### PR TITLE
Wait for alert index mapping to be present before creating alerts

### DIFF
--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -95,12 +95,12 @@ export const generateAlerts = async (alertCount: number, hostCount: number, user
     process.exit(1);
   }
 
-  console.log(`Generating ${alertCount} alerts containing ${hostCount} hosts and ${userCount} users.`);
+  console.log(`Generating ${alertCount} alerts containing ${hostCount} hosts and ${userCount} users in space ${space}`);
   const concurrency = 10; // how many batches to send in parallel
   const batchSize = 2500; // number of alerts in a batch
   const no_overrides = {};
 
-  const batchOpForIndex = ({ userName, hostName } : { userName: string, hostName: string }) => alertToBatchOps(createAlerts(no_overrides, { userName, hostName }), getAlertIndex(space));
+  const batchOpForIndex = ({ userName, hostName } : { userName: string, hostName: string }) => alertToBatchOps(createAlerts(no_overrides, { userName, hostName, space }), getAlertIndex(space));
 
 
   console.log('Generating entity names...');

--- a/src/createAlerts.ts
+++ b/src/createAlerts.ts
@@ -3,9 +3,11 @@ import { faker } from '@faker-js/faker';
 function baseCreateAlerts({
   userName = 'user-1',
   hostName = 'host-1',
+  space = 'default'
 } : {
   userName?: string,
-  hostName?: string,
+    hostName?: string,
+  space?: string,
 } = {
 }) {
   return {
@@ -51,7 +53,7 @@ function baseCreateAlerts({
     'kibana.alert.rule.rule_type_id': 'siem.queryRule',
     'kibana.alert.rule.uuid': faker.string.uuid(),
     'kibana.space_ids': [
-      'default'
+      space
     ],
     'kibana.alert.rule.tags': [],
     '@timestamp': Date.now(),
@@ -110,10 +112,12 @@ export type BaseCreateAlertsReturnType = ReturnType<typeof baseCreateAlerts>;
 export default function createAlerts<O extends object>(override: O, {
   userName,
   hostName,
+  space
 } : {
   userName?: string,
-  hostName?: string,
+    hostName?: string,
+  space?: string,
 } = {
 }): O & BaseCreateAlertsReturnType {
-  return { ...baseCreateAlerts({ userName, hostName}), ...override };
+  return { ...baseCreateAlerts({ userName, hostName, space}), ...override };
 }

--- a/src/utils/initialize_space.ts
+++ b/src/utils/initialize_space.ts
@@ -13,6 +13,7 @@ export const initializeSpace = async (space: string) => {
   console.log(`Initializing space ${space}`);
   console.log(`Creating dummy rule to initialize alerts index in ${space}`);
   await kibanaApi.createRule({space,id: DUMMY_RULE_ID}); 
+  await waitForAlertIndexMapping(space);
   console.log('Deleting dummy rule');
   await kibanaApi.deleteRule(DUMMY_RULE_ID, space);
   console.log('Dummy rule deleted. Space initialized');
@@ -26,6 +27,49 @@ const alertIndexExistsInSpace = async (space: string): Promise<boolean> => {
 
   console.log(exists ? `Index ${index} exists` :  `Index ${index} does not exist`);
   return exists;
+}
+
+const waitForAlertIndexMapping = async (space: string, attempts: number = 5, waitSeconds = 5) => {
+  const client = getEsClient();
+  const index = getAlertIndex(space);
+  const backingIndex = '.internal' + index + '-000001';
+
+  console.log(`Waiting for index ${index} to have the correct mapping`);
+
+  let attempt = 0;
+
+  while (attempt < attempts) {
+    try {
+      const res = await client.indices.getMapping({ index });
+      console.log(`Got mapping for index ${index} (backing index ${backingIndex})`);
+      if (res[backingIndex]?.mappings?.properties) {
+        const mapping = res[backingIndex].mappings.properties;
+        // I use @timestamp to detect if the mapping is correct, if it has beem automatically created it will be long
+        if (mapping['@timestamp'] && mapping['@timestamp'].type === 'date') {
+          console.log(`Index ${index} has the correct date field mapping: ${JSON.stringify(mapping['@timestamp'])}`);
+          return;
+        } else {
+          throw new Error(`Index ${index} does not have the correct mapping`);
+        }
+      }
+
+      console.log(`Index ${index} does not have the correct mapping.`);
+    } catch (e) {
+      if (JSON.stringify(e).includes('index_not_found_exception')) {
+        console.log(`Index ${index} does not exist yet.`);
+      } else {
+        throw e;
+      }
+    }
+
+    if (attempt === attempts - 1) {
+      throw new Error(`Index ${index} does not have the correct mapping after ${attempts} attempts`);
+    }
+
+    console.log(`Waiting ${waitSeconds} seconds before trying again`);
+    await new Promise((resolve) => setTimeout(resolve, waitSeconds * 1000));
+    attempt++;
+  }
 }
 
 const ensureSpaceExists = async (space: string) => {


### PR DESCRIPTION
Add a step to the alerts generator which checks the alerts index mapping is there before we send the alerts.

In order to set up alerting and create the alerts index mapping, we create a rule as part of the alert generator script. Something has changed where this is taking longer than before, we had a race condition where the alerts were being sent before the mapping was present, this resulted in a dynamic and incorrect mapping being generated. 