### PR TITLE
Add generate-legacy-risk-score command

### DIFF
--- a/src/commands/legacy_risk_score.ts
+++ b/src/commands/legacy_risk_score.ts
@@ -1,0 +1,116 @@
+import { installLegacyRiskScore } from '../utils/kibana_api';
+import { getEsClient } from './utils';
+
+const esClient = getEsClient();
+
+/**
+ * Install legacy risk score and generate data
+ */
+export const generateLegacyRiskScore = async () => {
+
+  console.log('Installing legacy risk score');
+  
+  await installLegacyRiskScore();
+
+  console.log('Generating data');
+
+  await bulkIndexData();
+
+  console.log('Data generated');
+
+};
+
+const data = [
+  {
+    index: 'ml_host_risk_score_latest_default',
+    source: {
+      risk_stats: {
+        rule_risks: [
+          {
+            rule_id: '3301ee30-36d2-11ed-bc8e-edf6538225c3',
+            rule_name: 'test',
+            rule_risk: 21,
+          },
+        ],
+        risk_score: 17.084609494640123,
+        risk_multipliers: [],
+      },
+      '@timestamp': '2022-09-18T17:50:42.961Z',
+      host: {
+        name: 'MacBook-Pro.local',
+      },
+      ingest_timestamp: '2022-09-18T17:54:22.363192Z',
+      risk: 'Unknown',
+    },
+  },
+  {
+    index: 'ml_host_risk_score_default',
+    source: {
+      host: {
+        name: 'MacBook-Pro.local',
+      },
+      risk_stats: {
+        rule_risks: [
+          {
+            rule_id: '3301ee30-36d2-11ed-bc8e-edf6538225c3',
+            rule_name: 'test',
+            rule_risk: 21,
+          },
+        ],
+        risk_score: 17.084609494640123,
+        risk_multipliers: [],
+      },
+      ingest_timestamp: '2022-09-18T17:54:22.363192Z',
+      risk: 'Unknown',
+      '@timestamp': '2022-09-18T17:50:42.961Z',
+    },
+  },
+  {
+    id: 'Yb5XrKVhLNCdGL2ef-A3jloAAAAAAAAA',
+    index: 'ml_user_risk_score_latest_default',
+    source: {
+      risk_stats: {
+        rule_risks: [
+          {
+            rule_name: 'test',
+            rule_risk: 21,
+          },
+        ],
+        risk_score: 17.084609494640123,
+      },
+      '@timestamp': '2022-09-18T18:28:30.943Z',
+      ingest_timestamp: '2022-09-18T18:31:32.969840Z',
+      risk: 'Unknown',
+      user: {
+        name: 'johnsmith',
+      },
+    },
+  },
+  {
+    id: 'LrLLssaZUZHhh2cKbkwqIEpguUegcpuG9V+qzVlm8N0=',
+    index: 'ml_user_risk_score_default',
+    source: {
+      risk_stats: {
+        rule_risks: [
+          {
+            rule_name: 'test',
+            rule_risk: 21,
+          },
+        ],
+        risk_score: 17.084609494640123,
+      },
+      ingest_timestamp: '2022-09-18T18:31:32.969840Z',
+      risk: 'Unknown',
+      '@timestamp': '2022-09-18T18:28:30.943Z',
+      user: {
+        name: 'johnsmith',
+      },
+    },
+  },
+];
+
+const bulkIndexData = async () => {
+  const body = data.flatMap(doc => [{ index: { _index: doc.index } }, doc.source]);
+
+  await esClient.bulk({ refresh: true, body });
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,8 @@ export const generateNewSeed = () => {
 }
 
 // API Endpoint URL's for Kibana
+export const RISK_SCORE_URL = '/internal/risk_score';
+export const RISK_SCORE_DASHBOARD_URL = (entityType: 'host' | 'user') => `/internal/risk_score/prebuilt_content/saved_objects/_bulk_create/${entityType}RiskScoreDashboards`;
 export const RISK_SCORE_SCORES_URL = '/internal/risk_score/scores';
 export const RISK_SCORE_ENGINE_INIT_URL = '/internal/risk_score/engine/init';
 export const ASSET_CRITICALITY_URL = '/api/asset_criticality';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   generateEvents,
 } from './commands/documents';
 import { setupEntityResolutionDemo } from './commands/entity_resolution';
+import { generateLegacyRiskScore } from './commands/legacy_risk_score';
 import { kibanaApi } from './utils/';
 import {
   cleanEntityStore,
@@ -212,5 +213,11 @@ program
 
     generateAssetCriticality({ users, hosts });
   });
+
+
+program
+  .command('generate-legacy-risk-score')
+  .description('Install legacy risk score and generate data')
+  .action(generateLegacyRiskScore);
 
 program.parse();

--- a/src/utils/kibana_api.ts
+++ b/src/utils/kibana_api.ts
@@ -9,7 +9,9 @@ import {
   COMPONENT_TEMPLATES_URL,
   FLEET_EPM_PACKAGES_URL,
   SPACES_URL,
-  SPACE_URL, 
+  SPACE_URL,
+  RISK_SCORE_URL,
+  RISK_SCORE_DASHBOARD_URL, 
 } from '../constants';
 
 const config = getConfig();
@@ -165,6 +167,30 @@ export const installPackage = async ({ packageName, version = 'latest', space  }
     },
     '2023-10-31'
   );
+}
+
+export const installLegacyRiskScore = async () => {
+  const userResponse = await kibanaFetch(RISK_SCORE_URL, {
+    method: 'POST',
+    body: JSON.stringify({ riskScoreEntity: 'user' }),
+  });
+
+  const hostResponse = await kibanaFetch(RISK_SCORE_URL, {
+    method: 'POST',
+    body: JSON.stringify({ riskScoreEntity: 'host' }),
+  });
+
+  const userDashboardsResponse = await kibanaFetch(RISK_SCORE_DASHBOARD_URL('user'), {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+
+  const hostDashboardsResponse = await kibanaFetch(RISK_SCORE_DASHBOARD_URL('host'), {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+
+  return { userResponse, hostResponse, userDashboardsResponse, hostDashboardsResponse };
 }
 
 


### PR DESCRIPTION
This command installs the legacy risk engine and adds some host and user data.

I have added it to test the legacy risk score deprecation upgrade assistant warning in 8.18. 

