### PR TITLE
Add correct risk fields and set timestamp to `now` on legacy risk engine docs

### DIFF
--- a/src/commands/legacy_risk_score.ts
+++ b/src/commands/legacy_risk_score.ts
@@ -32,12 +32,22 @@ const data = [
             rule_risk: 21,
           },
         ],
-        risk_score: 17.084609494640123,
+        risk_score: 21.084609494640123,
         risk_multipliers: [],
       },
       '@timestamp': '2022-09-18T17:50:42.961Z',
       host: {
         name: 'MacBook-Pro.local',
+        risk: {
+          calculated_level: 'Low',
+          calculated_score_norm: 21,
+          rule_risks: [
+            {
+              rule_name: 'test',
+              rule_risk: 21,
+            },
+          ]
+        }
       },
       ingest_timestamp: '2022-09-18T17:54:22.363192Z',
       risk: 'Unknown',
@@ -48,6 +58,16 @@ const data = [
     source: {
       host: {
         name: 'MacBook-Pro.local',
+        risk: {
+          calculated_level: 'Low',
+          calculated_score_norm: 21,
+          rule_risks: [
+            {
+              rule_name: 'test',
+              rule_risk: 21,
+            },
+          ]
+        }
       },
       risk_stats: {
         rule_risks: [
@@ -57,7 +77,7 @@ const data = [
             rule_risk: 21,
           },
         ],
-        risk_score: 17.084609494640123,
+        risk_score: 21.084609494640123,
         risk_multipliers: [],
       },
       ingest_timestamp: '2022-09-18T17:54:22.363192Z',
@@ -76,13 +96,23 @@ const data = [
             rule_risk: 21,
           },
         ],
-        risk_score: 17.084609494640123,
+        risk_score: 21.084609494640123,
       },
       '@timestamp': '2022-09-18T18:28:30.943Z',
       ingest_timestamp: '2022-09-18T18:31:32.969840Z',
       risk: 'Unknown',
       user: {
         name: 'johnsmith',
+        risk: {
+          calculated_level: 'Low',
+          calculated_score_norm: 21,
+          rule_risks: [
+            {
+              rule_name: 'test',
+              rule_risk: 21,
+            },
+          ]
+        }
       },
     },
   },
@@ -97,20 +127,33 @@ const data = [
             rule_risk: 21,
           },
         ],
-        risk_score: 17.084609494640123,
+        risk_score: 21.084609494640123,
       },
       ingest_timestamp: '2022-09-18T18:31:32.969840Z',
       risk: 'Unknown',
       '@timestamp': '2022-09-18T18:28:30.943Z',
       user: {
         name: 'johnsmith',
+        risk: {
+          calculated_level: 'Low',
+          calculated_score_norm: 21,
+          rule_risks: [
+            {
+              rule_name: 'test',
+              rule_risk: 21,
+            },
+          ]
+        }
       },
     },
   },
 ];
 
 const bulkIndexData = async () => {
-  const body = data.flatMap(doc => [{ index: { _index: doc.index } }, doc.source]);
+  const body = data.flatMap(doc => {
+    doc.source['@timestamp'] = new Date().toISOString();
+    return [{ index: { _index: doc.index } }, doc.source];
+  });
 
   await esClient.bulk({ refresh: true, body });
 }


### PR DESCRIPTION
Previously, the legacy risk score documents were from 2022 so didn't show uo in the UI without adding a filter.

We also had some missing risk score fields which meant that table wasn't populated correctly.