### PR TITLE
Chore: simplify github action 

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -11,17 +11,13 @@ jobs:
     name: Lint and Type Check
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [22.14.0]
-
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 22.14.0
       uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 22.14.0
 
     - name: Build
       run: |


### PR DESCRIPTION
The matrix action allows you to test with multiple node versions, we only need one. 

The matrix puts the node version in the build title and means I have to update the merge condition to the new job name every time we update the node version, removing the matrix should remove the node version from the build name and 
stop this 🤞 