### PR TITLE
Improve legacy risk score data

### DIFF
--- a/src/commands/legacy_risk_score.ts
+++ b/src/commands/legacy_risk_score.ts
@@ -22,17 +22,6 @@ const data = [
   {
     index: 'ml_host_risk_score_latest_default',
     source: {
-      risk_stats: {
-        rule_risks: [
-          {
-            rule_id: '3301ee30-36d2-11ed-bc8e-edf6538225c3',
-            rule_name: 'test',
-            rule_risk: 21,
-          },
-        ],
-        risk_score: 21.084609494640123,
-        risk_multipliers: [],
-      },
       '@timestamp': '2022-09-18T17:50:42.961Z',
       host: {
         name: 'MacBook-Pro.local',
@@ -48,7 +37,6 @@ const data = [
         },
       },
       ingest_timestamp: '2022-09-18T17:54:22.363192Z',
-      risk: 'Unknown',
     },
   },
   {
@@ -67,19 +55,7 @@ const data = [
           ],
         },
       },
-      risk_stats: {
-        rule_risks: [
-          {
-            rule_id: '3301ee30-36d2-11ed-bc8e-edf6538225c3',
-            rule_name: 'test',
-            rule_risk: 21,
-          },
-        ],
-        risk_score: 21.084609494640123,
-        risk_multipliers: [],
-      },
       ingest_timestamp: '2022-09-18T17:54:22.363192Z',
-      risk: 'Unknown',
       '@timestamp': '2022-09-18T17:50:42.961Z',
     },
   },
@@ -87,18 +63,8 @@ const data = [
     id: 'Yb5XrKVhLNCdGL2ef-A3jloAAAAAAAAA',
     index: 'ml_user_risk_score_latest_default',
     source: {
-      risk_stats: {
-        rule_risks: [
-          {
-            rule_name: 'test',
-            rule_risk: 21,
-          },
-        ],
-        risk_score: 21.084609494640123,
-      },
       '@timestamp': '2022-09-18T18:28:30.943Z',
       ingest_timestamp: '2022-09-18T18:31:32.969840Z',
-      risk: 'Unknown',
       user: {
         name: 'johnsmith',
         risk: {
@@ -118,17 +84,7 @@ const data = [
     id: 'LrLLssaZUZHhh2cKbkwqIEpguUegcpuG9V+qzVlm8N0=',
     index: 'ml_user_risk_score_default',
     source: {
-      risk_stats: {
-        rule_risks: [
-          {
-            rule_name: 'test',
-            rule_risk: 21,
-          },
-        ],
-        risk_score: 21.084609494640123,
-      },
       ingest_timestamp: '2022-09-18T18:31:32.969840Z',
-      risk: 'Unknown',
       '@timestamp': '2022-09-18T18:28:30.943Z',
       user: {
         name: 'johnsmith',
@@ -150,6 +106,7 @@ const data = [
 const bulkIndexData = async () => {
   const body = data.flatMap((doc) => {
     doc.source['@timestamp'] = new Date().toISOString();
+    doc.source.ingest_timestamp = new Date().toISOString();
     return [{ index: { _index: doc.index } }, doc.source];
   });
 


### PR DESCRIPTION
In recreating a bug with some real legacy data I noticed the data the tool was generating was not 100% representative.