### PR TITLE
add quick-entity-store command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,28 @@ program
   });
 
 program
+  .command('quick-entity-store')
+  .description('Generate quick entity store')
+  .option('--space <space>', 'Space to create entity store in')
+  .action(async (options) => {
+    const space = options.space || 'default';
+
+    generateEntityStore({
+      space,
+      users: 10,
+      hosts: 10,
+      services: 10,
+      genericEntities: 10,
+      seed: generateNewSeed(),
+      options: [
+        ENTITY_STORE_OPTIONS.criticality,
+        ENTITY_STORE_OPTIONS.riskEngine,
+        ENTITY_STORE_OPTIONS.rule,
+      ],
+    });
+  });
+
+program
   .command('clean-entity-store')
   .description('clean entity store')
   .action(cleanEntityStore);


### PR DESCRIPTION
A version of the entity store commands with 10 of each entity type, the risk engine enabled, a rule created an asset criticality assigned. Saves pressing enter a lot of times!