### PR TITLE
Okta Integration Generate Data

### DIFF
--- a/src/commands/privileged_user_monitoring/privileged_user_monitoring.ts
+++ b/src/commands/privileged_user_monitoring/privileged_user_monitoring.ts
@@ -69,9 +69,11 @@ const getSampleOktaLogs = (users: User[]) => {
 export function getSampleOktaUsersLogs(count: number) {
   const adminCount = Math.round((50 / 100) * count);
   const nonAdminCount = Math.max(0, count - adminCount);
-  console.log(`Generating ${adminCount} admin users and ${nonAdminCount} non-admin users (total ${count})`);
+  console.log(
+    `Generating ${adminCount} admin users and ${nonAdminCount} non-admin users (total ${count})`,
+  );
   const adminDocs = Array.from({ length: adminCount }, () => makeDoc(true));
-  const userDocs  = Array.from({ length: nonAdminCount }, () => makeDoc(false));
+  const userDocs = Array.from({ length: nonAdminCount }, () => makeDoc(false));
   const docs = adminDocs.concat(userDocs);
   return docs;
 }
@@ -99,19 +101,23 @@ export const generatePrivilegedUserMonitoringData = async ({
       ...getSampleEndpointAccountSwitchLogs(users),
     ]);
 
-    await reinitializeDataStream(systemLogsDataStreamName, getSampleSystemLogs(users));
+    await reinitializeDataStream(
+      systemLogsDataStreamName,
+      getSampleSystemLogs(users),
+    );
 
     await reinitializeDataStream(oktaLogsDataStreamName, [
       ...getSampleOktaLogs(users),
-      ...getSampleOktaAuthenticationLogs(users)]);    
+      ...getSampleOktaAuthenticationLogs(users),
+    ]);
   } catch (e) {
     console.log(e);
   }
 };
 
 /**
- * Generate data for integrations sync only. 
- * Currently okta data only. 
+ * Generate data for integrations sync only.
+ * Currently okta data only.
  */
 export const generatePrivilegedUserIntegrationsSyncData = async ({
   usersCount,
@@ -146,8 +152,11 @@ const deleteDataStream = async (indexName: string) => {
   await new Promise((r) => setTimeout(r, 1000));
 };
 
-const reinitializeDataStream = async (indexName: string, documents: Array<object>) => {
+const reinitializeDataStream = async (
+  indexName: string,
+  documents: Array<object>,
+) => {
   await deleteDataStream(indexName);
   await createDataStream(indexName);
   await ingestIntoSourceIndex(indexName, documents);
-}
+};

--- a/src/commands/privileged_user_monitoring/privileged_user_monitoring.ts
+++ b/src/commands/privileged_user_monitoring/privileged_user_monitoring.ts
@@ -81,26 +81,17 @@ export const generatePrivilegedUserMonitoringData = async ({
   users: User[];
 }) => {
   try {
-    await deleteDataStream(endpointLogsDataStreamName);
-    await createDataStream(endpointLogsDataStreamName);
-    await ingestIntoSourceIndex(endpointLogsDataStreamName, [
+    await reinitializeDataStream(endpointLogsDataStreamName, [
       ...getSampleEndpointLogs(users),
       ...getSampleEndpointAccountSwitchLogs(users),
     ]);
 
-    await deleteDataStream(systemLogsDataStreamName);
-    await createDataStream(systemLogsDataStreamName);
-    await ingestIntoSourceIndex(
-      systemLogsDataStreamName,
-      getSampleSystemLogs(users),
-    );
+    await reinitializeDataStream(systemLogsDataStreamName, getSampleSystemLogs(users));
 
-    await deleteDataStream(oktaLogsDataStreamName);
-    await createDataStream(oktaLogsDataStreamName);
-    await ingestIntoSourceIndex(oktaLogsDataStreamName, [
+    await reinitializeDataStream(oktaLogsDataStreamName, [
       ...getSampleOktaLogs(users),
-      ...getSampleOktaAuthenticationLogs(users),
-    ]);
+      ...getSampleOktaAuthenticationLogs(users)]); 
+
   } catch (e) {
     console.log(e);
   }
@@ -125,3 +116,9 @@ const deleteDataStream = async (indexName: string) => {
   // Wait in order to ensure no race conditions after deletion
   await new Promise((r) => setTimeout(r, 1000));
 };
+
+const reinitializeDataStream = async(indexName: string, documents: Array<object>)=>{ 
+  await deleteDataStream(indexName);
+  await createDataStream(indexName);
+  await ingestIntoSourceIndex(indexName, documents);  
+}

--- a/src/commands/privileged_user_monitoring/privileged_user_monitoring.ts
+++ b/src/commands/privileged_user_monitoring/privileged_user_monitoring.ts
@@ -11,9 +11,12 @@ import {
 import { TimeWindows } from '../utils/time_windows';
 import { User } from '../privileged_access_detection_ml/event_generator';
 
+import { makeDoc } from '../utils/okta_utils';
+
 const endpointLogsDataStreamName = 'logs-endpoint.events.process-default';
 const systemLogsDataStreamName = 'logs-system.security-default';
 const oktaLogsDataStreamName = 'logs-okta.system-default';
+const oktaLogsUsersDataStreamName = 'logs-entityanalytics_okta.user-default';
 
 const getSampleEndpointLogs = (users: User[]) => {
   return faker.helpers.multiple(
@@ -63,6 +66,16 @@ const getSampleOktaLogs = (users: User[]) => {
   );
 };
 
+export function getSampleOktaUsersLogs(count: number) {
+  const adminCount = Math.round((50 / 100) * count);
+  const nonAdminCount = Math.max(0, count - adminCount);
+  console.log(`Generating ${adminCount} admin users and ${nonAdminCount} non-admin users (total ${count})`);
+  const adminDocs = Array.from({ length: adminCount }, () => makeDoc(true));
+  const userDocs  = Array.from({ length: nonAdminCount }, () => makeDoc(false));
+  const docs = adminDocs.concat(userDocs);
+  return docs;
+}
+
 const getSampleOktaAuthenticationLogs = (users: User[]) => {
   return faker.helpers.multiple(
     () => {
@@ -90,8 +103,24 @@ export const generatePrivilegedUserMonitoringData = async ({
 
     await reinitializeDataStream(oktaLogsDataStreamName, [
       ...getSampleOktaLogs(users),
-      ...getSampleOktaAuthenticationLogs(users)]); 
+      ...getSampleOktaAuthenticationLogs(users)]);    
+  } catch (e) {
+    console.log(e);
+  }
+};
 
+/**
+ * Generate data for integrations sync only. 
+ * Currently okta data only. 
+ */
+export const generatePrivilegedUserIntegrationsSyncData = async ({
+  usersCount,
+}: {
+  usersCount: number;
+}) => {
+  try {
+    const sampleDocuments = getSampleOktaUsersLogs(usersCount);
+    await reinitializeDataStream(oktaLogsUsersDataStreamName, sampleDocuments);
   } catch (e) {
     console.log(e);
   }
@@ -117,8 +146,8 @@ const deleteDataStream = async (indexName: string) => {
   await new Promise((r) => setTimeout(r, 1000));
 };
 
-const reinitializeDataStream = async(indexName: string, documents: Array<object>)=>{ 
+const reinitializeDataStream = async (indexName: string, documents: Array<object>) => {
   await deleteDataStream(indexName);
   await createDataStream(indexName);
-  await ingestIntoSourceIndex(indexName, documents);  
+  await ingestIntoSourceIndex(indexName, documents);
 }

--- a/src/commands/privileged_user_monitoring/sample_documents.ts
+++ b/src/commands/privileged_user_monitoring/sample_documents.ts
@@ -428,170 +428,157 @@ export const GRANTED_RIGHTS_WINDOWS_SAMPLE_DOCUMENT = (
   };
 };
 
-
-export const OKTA_USERS_SAMPLE_DOCUMENT = (oktaSampleUser: OktaSampleUser, timestamp: string, roles: string[] ) => { 
-  const { email, firstName, lastName, userId, userName } = oktaSampleUser
-  return  {
-          "agent": {
-            "name": "test-ea-april-2025",
-            "id": "38ea09b4-0b3c-4c71-81ef-0342fdd249a8",
-            "type": "filebeat",
-            "ephemeral_id": "4aae04bb-75fd-42a6-bf52-c0b0a1823dc6",
-            "version": "8.18.3"
-          },
-          "elastic_agent": {
-            "id": "38ea09b4-0b3c-4c71-81ef-0342fdd249a8",
-            "version": "8.18.3",
-            "snapshot": true
-          },
-          "entityanalytics_okta": {
-            "roles": [
-              {
-                "last_updated": "2023-02-22T17:44:08.000Z",
-                "_links": {
-                  "assignee": {
-                    "href": "https://dev-36006609.okta.com/api/v1/users/00u8fgtuln5yWODnG5d7"
-                  }
-                },
-                "created": "2023-02-22T17:44:08Z",
-                "assignment_type": "USER",
-                "id": "ra18fgz9a0OfCQOyn5d7",
-                "label": "Super Administrator",
-                "type": "SUPER_ADMIN",
-                "status": "ACTIVE"
-              }
-            ],
-            "groups": [
-              {
-                "profile": {
-                  "name": "Everyone",
-                  "description": "All users in your organization"
-                },
-                "id": "00gf1r6hcrcl7gaTH5d6"
-              }
-            ],
-            "user": {
-              "credentials": {
-                "recovery_question": {
-                  "is_set": false
-                }
-              },
-              "_links": {
-                "self": {
-                  "href": "https://dev-36006609.okta.com/api/v1/users/00u8fgtuln5yWODnG5d7"
-                }
-              },
-              "type": {
-                "id": "otyf1r6hlGf9AXhZ95d6"
-              }
-            }
-          },
-          "labels": {
-            "identity_source": "entity-analytics-entityanalytics_okta.entity-db4f0fd2-9dbc-47a8-8f72-c7bee68c2ce3"
-          },
-          "tags": [
-            "forwarded",
-            "entityanalytics_okta-entity"
-          ],
-          "cloud": {
-            "availability_zone": "us-east1-b",
-            "instance": {
-              "name": "test-ea-april-2025",
-              "id": "2595859665373623247"
+export const OKTA_USERS_SAMPLE_DOCUMENT = (
+  oktaSampleUser: OktaSampleUser,
+  timestamp: string,
+  roles: string[],
+) => {
+  const { email, firstName, lastName, userId, userName } = oktaSampleUser;
+  return {
+    agent: {
+      name: 'test-ea-april-2025',
+      id: '38ea09b4-0b3c-4c71-81ef-0342fdd249a8',
+      type: 'filebeat',
+      ephemeral_id: '4aae04bb-75fd-42a6-bf52-c0b0a1823dc6',
+      version: '8.18.3',
+    },
+    elastic_agent: {
+      id: '38ea09b4-0b3c-4c71-81ef-0342fdd249a8',
+      version: '8.18.3',
+      snapshot: true,
+    },
+    entityanalytics_okta: {
+      roles: [
+        {
+          last_updated: '2023-02-22T17:44:08.000Z',
+          _links: {
+            assignee: {
+              href: 'https://dev-36006609.okta.com/api/v1/users/00u8fgtuln5yWODnG5d7',
             },
-            "provider": "gcp",
-            "machine": {
-              "type": "e2-medium"
-            },
-            "service": {
-              "name": "GCE"
-            },
-            "project": {
-              "id": "elastic-security-dev"
-            },
-            "region": "us-east1",
-            "account": {
-              "id": "elastic-security-dev"
-            }
           },
-          "input": {
-            "type": "entity-analytics"
+          created: '2023-02-22T17:44:08Z',
+          assignment_type: 'USER',
+          id: 'ra18fgz9a0OfCQOyn5d7',
+          label: 'Super Administrator',
+          type: 'SUPER_ADMIN',
+          status: 'ACTIVE',
+        },
+      ],
+      groups: [
+        {
+          profile: {
+            name: 'Everyone',
+            description: 'All users in your organization',
           },
-          "@timestamp": timestamp,
-          "ecs": {
-            "version": "8.11.0"
+          id: '00gf1r6hcrcl7gaTH5d6',
+        },
+      ],
+      user: {
+        credentials: {
+          recovery_question: {
+            is_set: false,
           },
-          "related": {
-            "user": [
-              userId,
-              email,
-              firstName,
-              lastName
-            ]
+        },
+        _links: {
+          self: {
+            href: 'https://dev-36006609.okta.com/api/v1/users/00u8fgtuln5yWODnG5d7',
           },
-          "data_stream": {
-            "namespace": "default",
-            "type": "logs",
-            "dataset": "entityanalytics_okta.user"
-          },
-          "host": {
-            "name": "dev-36006609.okta.com"
-          },
-          "event": {
-            "agent_id_status": "verified",
-            "ingested": "2025-08-19T10:55:06Z",
-            "kind": "asset",
-            "category": [
-              "iam"
-            ],
-            "type": [
-              "user",
-              "info"
-            ],
-            "dataset": "entityanalytics_okta.user"
-          },
-          "asset": {
-            "last_updated": "2023-02-22T17:32:00.000Z",
-            "last_status_change_date": "2023-02-22T17:32:00.000Z",
-            "id": "00u8fgtuln5yWODnG5d7",
-            "category": "entity",
-            "type": "okta_user",
-            "create_date": "2023-02-22T17:32:00.000Z",
-            "status": "PROVISIONED"
-          },
-          "user": {
-            "profile": {
-              "last_name": lastName,
-              "first_name": firstName,
-              "status": "PROVISIONED"
-            },
-            "roles": roles,
-            "name": userName,
-            "id": "00u8fgtuln5yWODnG5d7",
-            "account": {
-              "change_date": "2023-02-22T17:32:00.000Z",
-              "activated_date": "2023-02-22T17:32:00.000Z",
-              "create_date": "2023-02-22T17:32:00.000Z",
-              "status": {
-                "password_expired": false,
-                "deprovisioned": false,
-                "locked_out": false,
-                "recovery": false,
-                "suspended": false
-              }
-            },
-            "email": email,
-            "group": {
-              "name": [
-                "Everyone"
-              ],
-              "id": [
-                "00gf1r6hcrcl7gaTH5d6"
-              ]
-            }
-          }
-      }
-}
+        },
+        type: {
+          id: 'otyf1r6hlGf9AXhZ95d6',
+        },
+      },
+    },
+    labels: {
+      identity_source:
+        'entity-analytics-entityanalytics_okta.entity-db4f0fd2-9dbc-47a8-8f72-c7bee68c2ce3',
+    },
+    tags: ['forwarded', 'entityanalytics_okta-entity'],
+    cloud: {
+      availability_zone: 'us-east1-b',
+      instance: {
+        name: 'test-ea-april-2025',
+        id: '2595859665373623247',
+      },
+      provider: 'gcp',
+      machine: {
+        type: 'e2-medium',
+      },
+      service: {
+        name: 'GCE',
+      },
+      project: {
+        id: 'elastic-security-dev',
+      },
+      region: 'us-east1',
+      account: {
+        id: 'elastic-security-dev',
+      },
+    },
+    input: {
+      type: 'entity-analytics',
+    },
+    '@timestamp': timestamp,
+    ecs: {
+      version: '8.11.0',
+    },
+    related: {
+      user: [userId, email, firstName, lastName],
+    },
+    data_stream: {
+      namespace: 'default',
+      type: 'logs',
+      dataset: 'entityanalytics_okta.user',
+    },
+    host: {
+      name: 'dev-36006609.okta.com',
+    },
+    event: {
+      agent_id_status: 'verified',
+      ingested: '2025-08-19T10:55:06Z',
+      kind: 'asset',
+      category: ['iam'],
+      type: ['user', 'info'],
+      dataset: 'entityanalytics_okta.user',
+    },
+    asset: {
+      last_updated: '2023-02-22T17:32:00.000Z',
+      last_status_change_date: '2023-02-22T17:32:00.000Z',
+      id: '00u8fgtuln5yWODnG5d7',
+      category: 'entity',
+      type: 'okta_user',
+      create_date: '2023-02-22T17:32:00.000Z',
+      status: 'PROVISIONED',
+    },
+    user: {
+      profile: {
+        last_name: lastName,
+        first_name: firstName,
+        status: 'PROVISIONED',
+      },
+      roles: roles,
+      name: userName,
+      id: '00u8fgtuln5yWODnG5d7',
+      account: {
+        change_date: '2023-02-22T17:32:00.000Z',
+        activated_date: '2023-02-22T17:32:00.000Z',
+        create_date: '2023-02-22T17:32:00.000Z',
+        status: {
+          password_expired: false,
+          deprovisioned: false,
+          locked_out: false,
+          recovery: false,
+          suspended: false,
+        },
+      },
+      email: email,
+      group: {
+        name: ['Everyone'],
+        id: ['00gf1r6hcrcl7gaTH5d6'],
+      },
+    },
+  };
+};
 
 export const GRANTED_RIGHTS_OKTA_SAMPLE_DOCUMENT = (
   userName: string,
@@ -1264,4 +1251,3 @@ export const OKTA_AUTHENTICATION = (userName: string, timestamp: string) => {
     },
   };
 };
-

--- a/src/commands/privileged_user_monitoring/sample_documents.ts
+++ b/src/commands/privileged_user_monitoring/sample_documents.ts
@@ -1,3 +1,4 @@
+import { OktaSampleUser } from '../utils/okta_utils';
 import {
   userNameAsEmail,
   userNameWhitespaceRemoved,
@@ -426,6 +427,171 @@ export const GRANTED_RIGHTS_WINDOWS_SAMPLE_DOCUMENT = (
     },
   };
 };
+
+
+export const OKTA_USERS_SAMPLE_DOCUMENT = (oktaSampleUser: OktaSampleUser, timestamp: string, roles: string[] ) => { 
+  const { email, firstName, lastName, userId, userName } = oktaSampleUser
+  return  {
+          "agent": {
+            "name": "test-ea-april-2025",
+            "id": "38ea09b4-0b3c-4c71-81ef-0342fdd249a8",
+            "type": "filebeat",
+            "ephemeral_id": "4aae04bb-75fd-42a6-bf52-c0b0a1823dc6",
+            "version": "8.18.3"
+          },
+          "elastic_agent": {
+            "id": "38ea09b4-0b3c-4c71-81ef-0342fdd249a8",
+            "version": "8.18.3",
+            "snapshot": true
+          },
+          "entityanalytics_okta": {
+            "roles": [
+              {
+                "last_updated": "2023-02-22T17:44:08.000Z",
+                "_links": {
+                  "assignee": {
+                    "href": "https://dev-36006609.okta.com/api/v1/users/00u8fgtuln5yWODnG5d7"
+                  }
+                },
+                "created": "2023-02-22T17:44:08Z",
+                "assignment_type": "USER",
+                "id": "ra18fgz9a0OfCQOyn5d7",
+                "label": "Super Administrator",
+                "type": "SUPER_ADMIN",
+                "status": "ACTIVE"
+              }
+            ],
+            "groups": [
+              {
+                "profile": {
+                  "name": "Everyone",
+                  "description": "All users in your organization"
+                },
+                "id": "00gf1r6hcrcl7gaTH5d6"
+              }
+            ],
+            "user": {
+              "credentials": {
+                "recovery_question": {
+                  "is_set": false
+                }
+              },
+              "_links": {
+                "self": {
+                  "href": "https://dev-36006609.okta.com/api/v1/users/00u8fgtuln5yWODnG5d7"
+                }
+              },
+              "type": {
+                "id": "otyf1r6hlGf9AXhZ95d6"
+              }
+            }
+          },
+          "labels": {
+            "identity_source": "entity-analytics-entityanalytics_okta.entity-db4f0fd2-9dbc-47a8-8f72-c7bee68c2ce3"
+          },
+          "tags": [
+            "forwarded",
+            "entityanalytics_okta-entity"
+          ],
+          "cloud": {
+            "availability_zone": "us-east1-b",
+            "instance": {
+              "name": "test-ea-april-2025",
+              "id": "2595859665373623247"
+            },
+            "provider": "gcp",
+            "machine": {
+              "type": "e2-medium"
+            },
+            "service": {
+              "name": "GCE"
+            },
+            "project": {
+              "id": "elastic-security-dev"
+            },
+            "region": "us-east1",
+            "account": {
+              "id": "elastic-security-dev"
+            }
+          },
+          "input": {
+            "type": "entity-analytics"
+          },
+          "@timestamp": timestamp,
+          "ecs": {
+            "version": "8.11.0"
+          },
+          "related": {
+            "user": [
+              userId,
+              email,
+              firstName,
+              lastName
+            ]
+          },
+          "data_stream": {
+            "namespace": "default",
+            "type": "logs",
+            "dataset": "entityanalytics_okta.user"
+          },
+          "host": {
+            "name": "dev-36006609.okta.com"
+          },
+          "event": {
+            "agent_id_status": "verified",
+            "ingested": "2025-08-19T10:55:06Z",
+            "kind": "asset",
+            "category": [
+              "iam"
+            ],
+            "type": [
+              "user",
+              "info"
+            ],
+            "dataset": "entityanalytics_okta.user"
+          },
+          "asset": {
+            "last_updated": "2023-02-22T17:32:00.000Z",
+            "last_status_change_date": "2023-02-22T17:32:00.000Z",
+            "id": "00u8fgtuln5yWODnG5d7",
+            "category": "entity",
+            "type": "okta_user",
+            "create_date": "2023-02-22T17:32:00.000Z",
+            "status": "PROVISIONED"
+          },
+          "user": {
+            "profile": {
+              "last_name": lastName,
+              "first_name": firstName,
+              "status": "PROVISIONED"
+            },
+            "roles": roles,
+            "name": userName,
+            "id": "00u8fgtuln5yWODnG5d7",
+            "account": {
+              "change_date": "2023-02-22T17:32:00.000Z",
+              "activated_date": "2023-02-22T17:32:00.000Z",
+              "create_date": "2023-02-22T17:32:00.000Z",
+              "status": {
+                "password_expired": false,
+                "deprovisioned": false,
+                "locked_out": false,
+                "recovery": false,
+                "suspended": false
+              }
+            },
+            "email": email,
+            "group": {
+              "name": [
+                "Everyone"
+              ],
+              "id": [
+                "00gf1r6hcrcl7gaTH5d6"
+              ]
+            }
+          }
+      }
+}
 
 export const GRANTED_RIGHTS_OKTA_SAMPLE_DOCUMENT = (
   userName: string,
@@ -1098,3 +1264,4 @@ export const OKTA_AUTHENTICATION = (userName: string, timestamp: string) => {
     },
   };
 };
+

--- a/src/commands/utils/okta_utils.ts
+++ b/src/commands/utils/okta_utils.ts
@@ -1,0 +1,57 @@
+import { OKTA_USERS_SAMPLE_DOCUMENT } from "../privileged_user_monitoring/sample_documents";
+import { userNameAsEmail, userNameWhitespaceRemoved } from "./sample_data_helpers";
+import { TimeWindows } from "./time_windows";
+import { faker } from '@faker-js/faker';
+
+export const OKTA_ADMIN_USER_ROLES: string[] = [
+  'Super Administrator',
+  'Organization Administrator',
+  'Group Administrator',
+  'Application Administrator',
+  'Mobile Administrator',
+  'Help Desk Administrator',
+  'Report Administrator',
+  'API Access Management Administrator',
+  'Group Membership Administrator',
+  'Read-only Administrator',
+];
+
+export const OKTA_NON_ADMIN_USER_ROLES: string[] = [  
+  'Guest',
+  'Employee',
+  'Contractor',
+  'Intern',
+  'Temp',
+];
+
+export type OktaSampleUser = {
+  email: string,
+  firstName: string,
+  lastName: string,
+  userId: string,
+  userName: string
+};
+
+export const createOktaSampleUser = (): OktaSampleUser => {
+  const firstName = faker.person.firstName();
+  const lastName = faker.person.lastName();
+  const userId = faker.string.uuid();
+  const userName = userNameWhitespaceRemoved(`${firstName}.${lastName}`);
+  const email = userNameAsEmail(userName);
+  return {
+    email,
+    firstName,
+    lastName,
+    userId,
+    userName
+  };
+};
+
+// okta helpers for admin roles split
+export const pick = <T,>(a: T[]) => a[Math.floor(Math.random() * a.length)];
+export const makeDoc = (isAdmin: boolean) =>
+  OKTA_USERS_SAMPLE_DOCUMENT(
+    createOktaSampleUser(),                              // new user each doc
+    TimeWindows.toRandomTimestamp(TimeWindows.last30DayWindow()),
+    [isAdmin ? pick(OKTA_ADMIN_USER_ROLES) : pick(OKTA_NON_ADMIN_USER_ROLES)]
+  );

--- a/src/commands/utils/okta_utils.ts
+++ b/src/commands/utils/okta_utils.ts
@@ -1,6 +1,9 @@
-import { OKTA_USERS_SAMPLE_DOCUMENT } from "../privileged_user_monitoring/sample_documents";
-import { userNameAsEmail, userNameWhitespaceRemoved } from "./sample_data_helpers";
-import { TimeWindows } from "./time_windows";
+import { OKTA_USERS_SAMPLE_DOCUMENT } from '../privileged_user_monitoring/sample_documents';
+import {
+  userNameAsEmail,
+  userNameWhitespaceRemoved,
+} from './sample_data_helpers';
+import { TimeWindows } from './time_windows';
 import { faker } from '@faker-js/faker';
 
 export const OKTA_ADMIN_USER_ROLES: string[] = [
@@ -16,7 +19,7 @@ export const OKTA_ADMIN_USER_ROLES: string[] = [
   'Read-only Administrator',
 ];
 
-export const OKTA_NON_ADMIN_USER_ROLES: string[] = [  
+export const OKTA_NON_ADMIN_USER_ROLES: string[] = [
   'Guest',
   'Employee',
   'Contractor',
@@ -25,11 +28,11 @@ export const OKTA_NON_ADMIN_USER_ROLES: string[] = [
 ];
 
 export type OktaSampleUser = {
-  email: string,
-  firstName: string,
-  lastName: string,
-  userId: string,
-  userName: string
+  email: string;
+  firstName: string;
+  lastName: string;
+  userId: string;
+  userName: string;
 };
 
 export const createOktaSampleUser = (): OktaSampleUser => {
@@ -43,15 +46,15 @@ export const createOktaSampleUser = (): OktaSampleUser => {
     firstName,
     lastName,
     userId,
-    userName
+    userName,
   };
 };
 
 // okta helpers for admin roles split
-export const pick = <T,>(a: T[]) => a[Math.floor(Math.random() * a.length)];
+export const pick = <T>(a: T[]) => a[Math.floor(Math.random() * a.length)];
 export const makeDoc = (isAdmin: boolean) =>
   OKTA_USERS_SAMPLE_DOCUMENT(
-    createOktaSampleUser(),                              // new user each doc
+    createOktaSampleUser(), // new user each doc
     TimeWindows.toRandomTimestamp(TimeWindows.last30DayWindow()),
-    [isAdmin ? pick(OKTA_ADMIN_USER_ROLES) : pick(OKTA_NON_ADMIN_USER_ROLES)]
+    [isAdmin ? pick(OKTA_ADMIN_USER_ROLES) : pick(OKTA_NON_ADMIN_USER_ROLES)],
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,10 @@ export const PRIVILEGED_USER_MONITORING_OPTIONS = {
   csvFile: 'csvFile',
 } as const;
 
+export const PRIVILEGED_USER_INTEGRATIONS_SYNC_OPTIONS = {
+  sourceEventData: 'sourceEventData',
+} as const;
+
 export const generateNewSeed = () => {
   return Math.round(Math.random() * 100000);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,10 @@ import { createConfigFileOnFirstRun } from './utils/create_config_on_first_run';
 import { generatePrivilegedAccessDetectionData } from './commands/privileged_access_detection_ml/privileged_access_detection_ml';
 import { promptForFileSelection } from './commands/utils/cli_utils';
 import { UserGenerator } from './commands/privileged_access_detection_ml/event_generator';
-import { generatePrivilegedUserIntegrationsSyncData, generatePrivilegedUserMonitoringData } from './commands/privileged_user_monitoring/privileged_user_monitoring';
+import {
+  generatePrivilegedUserIntegrationsSyncData,
+  generatePrivilegedUserMonitoringData,
+} from './commands/privileged_user_monitoring/privileged_user_monitoring';
 import { generateCSVFile } from './commands/privileged_user_monitoring/generate_csv_file';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { checkbox, input } from '@inquirer/prompts';
 import {
   ENTITY_STORE_OPTIONS,
   generateNewSeed,
+  PRIVILEGED_USER_INTEGRATIONS_SYNC_OPTIONS,
   PRIVILEGED_USER_MONITORING_OPTIONS,
 } from './constants';
 import { initializeSpace } from './utils';
@@ -30,7 +31,7 @@ import { createConfigFileOnFirstRun } from './utils/create_config_on_first_run';
 import { generatePrivilegedAccessDetectionData } from './commands/privileged_access_detection_ml/privileged_access_detection_ml';
 import { promptForFileSelection } from './commands/utils/cli_utils';
 import { UserGenerator } from './commands/privileged_access_detection_ml/event_generator';
-import { generatePrivilegedUserMonitoringData } from './commands/privileged_user_monitoring/privileged_user_monitoring';
+import { generatePrivilegedUserIntegrationsSyncData, generatePrivilegedUserMonitoringData } from './commands/privileged_user_monitoring/privileged_user_monitoring';
 import { generateCSVFile } from './commands/privileged_user_monitoring/generate_csv_file';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -358,6 +359,11 @@ program
           value: PRIVILEGED_USER_MONITORING_OPTIONS.csvFile,
           checked: true,
         },
+        {
+          name: 'Whether to create integrations source events for okta users - AD coming soon.',
+          value: PRIVILEGED_USER_INTEGRATIONS_SYNC_OPTIONS.sourceEventData,
+          checked: true,
+        },
       ],
     });
 
@@ -368,7 +374,17 @@ program
       }),
     );
 
-    const users = UserGenerator.getUsers(userCount);
+    const users = UserGenerator.getUsers(userCount);    
+    if (
+      privilegedUserMonitoringAnswers.includes(
+        PRIVILEGED_USER_INTEGRATIONS_SYNC_OPTIONS.sourceEventData,
+      )
+    ) {      
+            
+      await generatePrivilegedUserIntegrationsSyncData({
+        usersCount: userCount
+      });
+    }
 
     if (
       privilegedUserMonitoringAnswers.includes(
@@ -387,7 +403,7 @@ program
         PRIVILEGED_USER_MONITORING_OPTIONS.csvFile,
       )
     )
-      await generateCSVFile({ users });
+      await generateCSVFile({ users }); 
   });
 
 program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,15 +377,14 @@ program
       }),
     );
 
-    const users = UserGenerator.getUsers(userCount);    
+    const users = UserGenerator.getUsers(userCount);
     if (
       privilegedUserMonitoringAnswers.includes(
         PRIVILEGED_USER_INTEGRATIONS_SYNC_OPTIONS.sourceEventData,
       )
-    ) {      
-            
+    ) {
       await generatePrivilegedUserIntegrationsSyncData({
-        usersCount: userCount
+        usersCount: userCount,
       });
     }
 
@@ -406,7 +405,7 @@ program
         PRIVILEGED_USER_MONITORING_OPTIONS.csvFile,
       )
     )
-      await generateCSVFile({ users }); 
+      await generateCSVFile({ users });
   });
 
 program.parse();


### PR DESCRIPTION
## Summary 
This PR introduces generated okta integrations data, with 50% of the data admin roles and 50% non admin roles. 

### How To Test
1. Run local kibana and elastic search 
2. `yarn start privileged-user-monitoring` then  (optionally) deselect the other options, and keep 'Whether to create integrations source events for okta users - AD coming soon." selected, input the number of users you want. 
3. Check the index for data, both amin roles and non admin roles: `GET logs-entityanalytics_okta.user-default/_search`