### PR TITLE
Fix crash on first run

### DIFF
--- a/src/commands/entity_store_perf/entity_store_perf.ts
+++ b/src/commands/entity_store_perf/entity_store_perf.ts
@@ -26,8 +26,6 @@ import {
 } from '../../types/entities.ts';
 import { getEntityStorePerfDataDir } from '../../utils/data_paths.ts';
 
-const config = getConfig();
-
 // Checkpoint stability configuration for transform completion detection
 // Consider checkpoint stable if it hasn't changed in this duration (10 seconds)
 const CHECKPOINT_STABLE_TIME_MS = 10000;
@@ -576,6 +574,7 @@ const waitForTransformToComplete = async (
 };
 
 const logClusterHealthEvery = (name: string, interval: number): (() => void) => {
+  const config = getConfig();
   if (config.serverless) {
     log.info('Skipping cluster health on serverless cluster');
     return () => {};
@@ -659,6 +658,7 @@ const logTransformStatsEvery = (name: string, interval: number): (() => void) =>
 };
 
 const logNodeStatsEvery = (name: string, interval: number): (() => void) => {
+  const config = getConfig();
   if (config.serverless) {
     log.info('Skipping node stats on serverless cluster');
     return () => {};


### PR DESCRIPTION
**Fixing first-run crash when no config file exists**

`getConfig()` was called at module level in `entity_store_perf.ts`, which runs at import time — before `createConfigFileOnFirstRun()` has a chance to create the config file. This caused the tool to crash immediately on first run.

**Fix:** Moved `getConfig()` calls into `logClusterHealthEvery` and `logNodeStatsEvery`, where they're actually needed.

<img width="1237" height="211" alt="Screenshot 2026-04-08 at 1 27 44 PM" src="https://github.com/user-attachments/assets/8c3a60c4-7304-449a-8a4a-cacec26b6b0b" />