### PR TITLE
Update entity store index name

### DIFF
--- a/src/commands/entity_store/entity_maintainers.ts
+++ b/src/commands/entity_store/entity_maintainers.ts
@@ -4,7 +4,7 @@ import { chunk } from 'lodash-es';
 import { getEsClient } from '../utils/indices.ts';
 import { bulkIngest, bulkUpsert } from '../shared/elasticsearch.ts';
 import {
-  getEntityStoreV2Index,
+  getEntityStoreIndex,
   ENTITY_MAINTAINERS_OPTIONS,
   DEFAULT_CHUNK_SIZE,
   type EntityMaintainerOption,
@@ -113,7 +113,7 @@ const fetchEntities = async (
   const client = getEsClient();
 
   const response = await client.search({
-    index: getEntityStoreV2Index(space),
+    index: getEntityStoreIndex(space),
     size: count,
     sort: [{ '@timestamp': 'desc' }],
     query: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,10 +16,9 @@ export const ENTITY_STORE_OPTIONS = {
   apiEnrichment: 'apiEnrichment',
 } as const;
 
-export const getEntityStoreV2Index = (space: string = 'default') =>
-  `.entities.v2.latest.security_${space}`;
+export const getEntityStoreIndex = (space: string = 'default') => `entities-latest-${space}`;
 
-export const ENTITY_STORE_V2_INDEX = getEntityStoreV2Index();
+export const ENTITY_STORE_INDEX = getEntityStoreIndex();
 export const ENTITY_MAINTAINERS_OPTIONS = {
   riskScore: 'riskScore',
   assetCriticality: 'assetCriticality',


### PR DESCRIPTION
Updating the Entity Store index name to match the change made on https://github.com/elastic/kibana/pull/260706

Error it was throwing:
<img width="1158" height="94" alt="Screenshot 2026-04-10 at 9 10 55 AM" src="https://github.com/user-attachments/assets/4c1de64d-9559-46bf-a9c6-a545e7e5f3cb" />