### PR TITLE
Add option to correlate anomalies to existing entities

### DIFF
--- a/src/commands/entity_store/entity_maintainers.ts
+++ b/src/commands/entity_store/entity_maintainers.ts
@@ -1,14 +1,13 @@
 import { log } from '../../utils/logger.ts';
 import { faker } from '@faker-js/faker';
 import { chunk } from 'lodash-es';
-import { getEsClient } from '../utils/indices.ts';
 import { bulkIngest, bulkUpsert } from '../shared/elasticsearch.ts';
 import {
-  getEntityStoreIndex,
   ENTITY_MAINTAINERS_OPTIONS,
   DEFAULT_CHUNK_SIZE,
   type EntityMaintainerOption,
 } from '../../constants.ts';
+import { fetchEntities, type EntityHit, type EntityHitSource } from '../utils/entity_store.ts';
 import { getAlertIndex } from '../../utils/index.ts';
 import createAlerts from '../../generators/create_alerts.ts';
 
@@ -64,67 +63,6 @@ const SYNTHETIC_SERVICES = [
   'Azure Portal',
   'VPN',
 ];
-
-interface EntityHitSource {
-  '@timestamp'?: string;
-  entity?: {
-    id?: string;
-    name?: string;
-    type?: string;
-    risk?: {
-      calculated_level?: string;
-      calculated_score?: number;
-      calculated_score_norm?: number;
-    };
-    behaviors?: {
-      rule_names?: string[];
-      anomaly_job_ids?: string[];
-    };
-    relationships?: Record<string, string[]>;
-    attributes?: {
-      watchlists?: string[];
-      [key: string]: unknown;
-    };
-  };
-  user?: {
-    name?: string;
-  };
-  host?: {
-    name?: string;
-  };
-  asset?: {
-    criticality?: string;
-    [key: string]: unknown;
-  };
-  [key: string]: unknown;
-}
-
-interface EntityHit {
-  _id: string;
-  _index: string;
-  _source: EntityHitSource;
-}
-
-const fetchEntities = async (
-  count: number,
-  space?: string,
-  type = 'Identity',
-): Promise<EntityHit[]> => {
-  const client = getEsClient();
-
-  const response = await client.search({
-    index: getEntityStoreIndex(space),
-    size: count,
-    sort: [{ '@timestamp': 'desc' }],
-    query: {
-      bool: {
-        filter: [{ term: { 'entity.type': type } }],
-      },
-    },
-  });
-
-  return response.hits.hits as unknown as EntityHit[];
-};
 
 const getEntityName = (entity: EntityHit): string | undefined =>
   entity._source?.entity?.name ?? entity._source?.user?.name;

--- a/src/commands/misc/anomalous_behavior/generators/ded_documents.ts
+++ b/src/commands/misc/anomalous_behavior/generators/ded_documents.ts
@@ -2,6 +2,146 @@ import { flatMap, range } from 'lodash-es';
 import { DED_JOB_IDS } from '../ml_modules_setup.ts';
 import { faker } from '@faker-js/faker';
 import { generateCommonFields } from './utils.ts';
+import type { HostIdentityForDed, UserIdentityForDed } from '../../../utils/entity_store.ts';
+
+/** Optional host/user pools from Entity Store. */
+export interface DedEntityCorpus {
+  hosts?: HostIdentityForDed[];
+  users?: UserIdentityForDed[];
+}
+
+/** Discriminated union: which identity type (if any) to apply to a record. `none` means keep the record's generated names as-is. */
+type CorrelateBranch =
+  | { kind: 'none' }
+  | { kind: 'host'; host: HostIdentityForDed }
+  | { kind: 'user'; user: UserIdentityForDed };
+
+/**
+ * Picks a user, host, or synthetic branch for record index `ndx`.
+ * Alternates between users and hosts when both pools are available.
+ * Pass `hostOnly: true` to force host selection (for host-partitioned jobs).
+ */
+const resolveCorrelateBranch = (
+  corpus: DedEntityCorpus | undefined,
+  ndx: number,
+  hostOnly = false,
+): CorrelateBranch => {
+  const hosts = corpus?.hosts?.length ? corpus.hosts : [];
+  const users = corpus?.users?.length ? corpus.users : [];
+  if (hostOnly) {
+    return hosts.length > 0 ? { kind: 'host', host: hosts[ndx % hosts.length]! } : { kind: 'none' };
+  }
+  if (hosts.length === 0 && users.length === 0) return { kind: 'none' };
+  if (hosts.length > 0 && users.length > 0) {
+    return ndx % 2 === 0
+      ? { kind: 'user', user: users[ndx % users.length]! }
+      : { kind: 'host', host: hosts[ndx % hosts.length]! };
+  }
+  if (users.length > 0) return { kind: 'user', user: users[ndx % users.length]! };
+  return { kind: 'host', host: hosts[ndx % hosts.length]! };
+};
+
+/** Best display name for a host, used as the influencer value. */
+const hostLabel = (h: HostIdentityForDed): string => h.name ?? h.id ?? 'host';
+
+/** ECS fields to inject into a record for a given host identity. */
+const buildHostFields = (h: HostIdentityForDed): Record<string, string[]> => {
+  const fields: Record<string, string[]> = {};
+  const effectiveName = h.name ?? h.id;
+  if (effectiveName) fields['host.name'] = [effectiveName];
+  if (h.id) fields['host.id'] = [h.id];
+  return fields;
+};
+
+/** Value aligned with `user.name` influencer / doc for applyV2Fields. */
+const userInfluencerPrimary = (u: UserIdentityForDed): string =>
+  u.ecsArrays['user.name']?.[0] ??
+  u.ecsArrays['user.id']?.[0] ??
+  u.ecsArrays['user.email']?.[0] ??
+  u.displayLabel;
+
+type Influencer = { influencer_field_name: string; influencer_field_values: string[] };
+
+// These jobs are partitioned by host.name in the real ML configuration, so only host identities are injected.
+const HOST_ONLY_JOB_IDS = new Set([
+  'ded_high_bytes_written_to_external_device',
+  'ded_high_bytes_written_to_external_device_airdrop',
+]);
+
+/**
+ * Overwrites the identity fields (user.name / host.name and related) on an
+ * already-generated synthetic record with real Entity Store values.
+ * Keeps every other field unchanged.
+ */
+const applyCorpusToRecord = (
+  record: Record<string, unknown>,
+  corpus: DedEntityCorpus,
+  ndx: number,
+): Record<string, unknown> => {
+  const jobId = record.job_id as string | undefined;
+  const br = resolveCorrelateBranch(corpus, ndx, Boolean(jobId && HOST_ONLY_JOB_IDS.has(jobId)));
+  if (br.kind === 'none') return record;
+
+  const result = { ...record };
+  const influencers = (result.influencers as Influencer[] | undefined) ?? [];
+  // Strip both identity fields from influencers; we'll add the winning one back.
+  const otherInfluencers = influencers.filter(
+    (inf) => inf.influencer_field_name !== 'user.name' && inf.influencer_field_name !== 'host.name',
+  );
+
+  if (br.kind === 'user') {
+    const { ecsArrays } = br.user;
+    const userName = userInfluencerPrimary(br.user);
+
+    // Clear host fields so user EUID wins the COALESCE in the ES|QL query.
+    delete result['host.name'];
+    delete result['host.id'];
+
+    // Inject real user ECS fields (user.name, user.id, event.module, …).
+    Object.assign(result, ecsArrays);
+
+    result.influencers = [
+      ...otherInfluencers,
+      { influencer_field_name: 'user.name', influencer_field_values: [userName] },
+    ];
+
+    // Some records are partitioned by host.name; flip to user.name.
+    if (
+      result.partition_field_name === 'host.name' ||
+      result.partition_field_name === 'user.name'
+    ) {
+      result.partition_field_name = 'user.name';
+      result.partition_field_value = userName;
+    }
+  } else {
+    const label = hostLabel(br.host);
+    const hostFields = buildHostFields(br.host);
+
+    // Clear user fields so host EUID wins the COALESCE in the ES|QL query.
+    delete result['user.name'];
+    delete result['user.id'];
+    delete result['event.module'];
+
+    // Inject real host ECS fields (host.name, host.id).
+    Object.assign(result, hostFields);
+
+    result.influencers = [
+      ...otherInfluencers,
+      { influencer_field_name: 'host.name', influencer_field_values: [label] },
+    ];
+
+    // Keep (or set) partition_field keyed on host.name with the real label.
+    if (
+      result.partition_field_name === 'user.name' ||
+      result.partition_field_name === 'host.name'
+    ) {
+      result.partition_field_name = 'host.name';
+      result.partition_field_value = label;
+    }
+  }
+
+  return result;
+};
 
 const generateDestinationIpRecord = (ndx: number) => {
   const commonFields = generateCommonFields();
@@ -237,22 +377,31 @@ const generateExternalDeviceRecord = (ndx: number) => {
   };
 };
 
-export const generateDedRecords = (numDocs: number = 10): Array<Record<string, unknown>> => {
+export const generateDedRecords = (
+  numDocs: number = 10,
+  corpus?: DedEntityCorpus,
+): Array<Record<string, unknown>> => {
   return flatMap(
     DED_JOB_IDS.map((jobId) => {
       return range(numDocs).map((val) => {
+        let record: Record<string, unknown>;
         switch (jobId) {
           case 'ded_high_bytes_written_to_external_device':
-            return generateExternalDeviceRecord(val);
+            record = generateExternalDeviceRecord(val);
+            break;
           case 'ded_high_bytes_written_to_external_device_airdrop':
-            return generateExternalDeviceAirdropRecord(val);
+            record = generateExternalDeviceAirdropRecord(val);
+            break;
           case 'ded_high_sent_bytes_destination_geo_country_iso_code':
-            return generateDestinationGeoCountryRecord(val);
+            record = generateDestinationGeoCountryRecord(val);
+            break;
           case 'ded_high_sent_bytes_destination_ip':
-            return generateDestinationIpRecord(val);
+            record = generateDestinationIpRecord(val);
+            break;
           default:
             throw new Error(`Unexpected job ID: ${jobId}`);
         }
+        return corpus ? applyCorpusToRecord(record, corpus, val) : record;
       });
     }),
   );

--- a/src/commands/misc/anomalous_behavior/generators/index.ts
+++ b/src/commands/misc/anomalous_behavior/generators/index.ts
@@ -1,7 +1,7 @@
 export { generateSecurityAuthRecords } from './security_auth_documents.ts';
 export { generatePadRecords } from './pad_documents.ts';
 export { generateLmdRecords } from './lmd_documents.ts';
-export { generateDedRecords } from './ded_documents.ts';
+export { generateDedRecords, type DedEntityCorpus } from './ded_documents.ts';
 export { generatePacketbeatRecords } from './packetbeat_documents.ts';
 export { generateSourceData } from './source_documents.ts';
 export { applyV2Fields } from './utils.ts';

--- a/src/commands/misc/anomalous_behavior/generators/utils.ts
+++ b/src/commands/misc/anomalous_behavior/generators/utils.ts
@@ -38,32 +38,56 @@ export const applyV2Fields = (record: Record<string, unknown>): Record<string, u
   const hostNames = result['host.name'] as string[] | undefined;
 
   if (userNames) {
-    result['user.id'] = userNames.map((n) => `${n}-id`);
-    result['event.module'] = [eventModule];
+    if (!(result['user.id'] as string[] | undefined)?.length) {
+      result['user.id'] = userNames.map((n) => `${n}-id`);
+    }
+    if (!(result['event.module'] as string[] | undefined)?.length) {
+      result['event.module'] = [eventModule];
+    }
   }
 
+  const existingHostIds = result['host.id'] as string[] | undefined;
   if (hostNames) {
-    result['host.id'] = hostNames.map((n) => `${n}-id`);
+    if (!existingHostIds?.length) {
+      result['host.id'] = hostNames.map((n) => `${n}-id`);
+    }
   }
 
   const influencers = result.influencers as Influencer[] | undefined;
   if (influencers) {
     const additions: Influencer[] = [];
+    const resolvedHostIds = result['host.id'] as string[] | undefined;
+    const resolvedUserIds = result['user.id'] as string[] | undefined;
+    const resolvedEventModule = result['event.module'] as string[] | undefined;
     for (const inf of influencers) {
       if (inf.influencer_field_name === 'user.name') {
-        additions.push({
-          influencer_field_name: 'user.id',
-          influencer_field_values: inf.influencer_field_values.map((n) => `${n}-id`),
-        });
+        if (resolvedUserIds && resolvedUserIds.length === inf.influencer_field_values.length) {
+          additions.push({
+            influencer_field_name: 'user.id',
+            influencer_field_values: resolvedUserIds,
+          });
+        } else {
+          additions.push({
+            influencer_field_name: 'user.id',
+            influencer_field_values: inf.influencer_field_values.map((n) => `${n}-id`),
+          });
+        }
         additions.push({
           influencer_field_name: 'event.module',
-          influencer_field_values: [eventModule],
+          influencer_field_values: resolvedEventModule ?? [eventModule],
         });
       } else if (inf.influencer_field_name === 'host.name') {
-        additions.push({
-          influencer_field_name: 'host.id',
-          influencer_field_values: inf.influencer_field_values.map((n) => `${n}-id`),
-        });
+        if (resolvedHostIds && resolvedHostIds.length === inf.influencer_field_values.length) {
+          additions.push({
+            influencer_field_name: 'host.id',
+            influencer_field_values: resolvedHostIds,
+          });
+        } else {
+          additions.push({
+            influencer_field_name: 'host.id',
+            influencer_field_values: inf.influencer_field_values.map((n) => `${n}-id`),
+          });
+        }
       }
     }
     result.influencers = [...influencers, ...additions];

--- a/src/commands/misc/anomalous_behavior/index.ts
+++ b/src/commands/misc/anomalous_behavior/index.ts
@@ -25,7 +25,11 @@ import {
   generatePacketbeatRecords,
   generateSourceData,
   applyV2Fields,
+  type DedEntityCorpus,
 } from './generators/index.ts';
+import { fetchHostIdentitiesForDed, fetchUserIdentitiesForDed } from '../../utils/entity_store.ts';
+
+const ENTITY_STORE_CORRELATION_MAX = 10;
 
 const WINDOWS_SERVICES_INDEX = 'winlogbeat-windows-services';
 const AUDITBEAT_HOSTS_INDEX = 'auditbeat-hosts';
@@ -100,9 +104,13 @@ const generatePacketbeatRecordData = async (recordCount: number, v2: boolean): P
   log.info(`Indexed ${records.length} anomaly record(s) into ${PACKETBEAT_ANOMALIES_INDEX}`);
 };
 
-const generateDedRecordData = async (recordCount: number, v2: boolean): Promise<void> => {
+const generateDedRecordData = async (
+  recordCount: number,
+  v2: boolean,
+  dedCorpus?: DedEntityCorpus,
+): Promise<void> => {
   log.info('Generating and indexing source data for DED ML module...');
-  const records = generateDedRecords(recordCount);
+  const records = generateDedRecords(recordCount, dedCorpus);
   const finalRecords = v2 ? records.map(applyV2Fields) : records;
   await bulkIngest({
     index: SHARED_ANOMALIES_INDEX,
@@ -119,6 +127,7 @@ const generateDedRecordData = async (recordCount: number, v2: boolean): Promise<
 const generateAnomalousBehaviorRecords = async (
   recordCount: number,
   v2: boolean,
+  dedCorpus?: DedEntityCorpus,
 ): Promise<void> => {
   log.info('Generating and indexing anomalous behavior ML records...');
 
@@ -126,7 +135,7 @@ const generateAnomalousBehaviorRecords = async (
   await generatePadRecordData(recordCount, v2);
   await generateLmdRecordData(recordCount, v2);
   await generatePacketbeatRecordData(recordCount, v2);
-  await generateDedRecordData(recordCount, v2);
+  await generateDedRecordData(recordCount, v2, dedCorpus);
 
   log.info(`Finished: generating anomalous behavior records`);
 };
@@ -180,13 +189,42 @@ export const generateAnomalousBehaviorDataWithMlJobs = async (
   recordCount: number,
   generateAnomalyData: boolean,
   v2 = false,
+  correlateWithEntityStore = false,
 ): Promise<void> => {
   await setupIndexMappings(space);
   await generateSource();
   await setupAnomalyMlModulesAndStartDatafeeds(space, generateAnomalyData, v2);
 
   if (!generateAnomalyData) {
-    await generateAnomalousBehaviorRecords(recordCount, v2);
+    let dedCorpus: DedEntityCorpus | undefined;
+
+    if (correlateWithEntityStore) {
+      const corpus: DedEntityCorpus = {};
+
+      const hosts = await fetchHostIdentitiesForDed(space, ENTITY_STORE_CORRELATION_MAX);
+      if (hosts.length === 0) {
+        log.warn(`No usable host identities.`);
+      } else {
+        corpus.hosts = hosts;
+      }
+
+      const users = await fetchUserIdentitiesForDed(space, ENTITY_STORE_CORRELATION_MAX);
+      if (users.length === 0) {
+        log.warn(`No usable user identities.`);
+      } else {
+        corpus.users = users;
+      }
+
+      if (!corpus.hosts?.length && !corpus.users?.length) {
+        log.error(
+          `Could not build any correlated host or user identities after fetch. Make sure to populate the entity store before using --correlate-with-entity-store.`,
+        );
+        process.exit(1);
+      }
+      dedCorpus = corpus;
+    }
+
+    await generateAnomalousBehaviorRecords(recordCount, v2, dedCorpus);
     await waitForAllJobsToStart(v2 ? ALL_ANOMALY_JOB_IDS_V2 : ALL_ANOMALY_JOB_IDS, space);
   }
 };

--- a/src/commands/misc/index.ts
+++ b/src/commands/misc/index.ts
@@ -32,6 +32,10 @@ export const miscCommands: CommandModule = {
         'create entity data and ML modules without starting datafeeds or generating anomalous behavior records',
       )
       .option('--v2', 'generate v2 ML anomaly data with user.id, host.id, and event.module fields')
+      .option(
+        '--correlate-with-entity-store',
+        'correlate generated anomaly data with entities from the entity store',
+      )
       .description(
         'Generate vulnerabilities, misconfigurations, ML jobs, and anomalous behavior for entities.',
       )
@@ -51,6 +55,7 @@ export const miscCommands: CommandModule = {
             generateAnomalies,
             generateAnomalyData,
             v2: options.v2 ?? false,
+            correlateWithEntityStore: Boolean(options.correlateWithEntityStore),
           });
         }),
       );

--- a/src/commands/misc/insights.ts
+++ b/src/commands/misc/insights.ts
@@ -27,6 +27,7 @@ interface GenerateAiInsightsOpts {
   generateAnomalyData: boolean;
   v2?: boolean;
   seed?: number;
+  correlateWithEntityStore?: boolean;
 }
 export const generateAiInsights = async ({
   users,
@@ -37,6 +38,7 @@ export const generateAiInsights = async ({
   generateAnomalyData,
   v2 = false,
   seed = generateNewSeed(),
+  correlateWithEntityStore = false,
 }: GenerateAiInsightsOpts) => {
   faker.seed(seed);
   const usersData = Array.from({ length: users }, () => ({
@@ -64,7 +66,13 @@ export const generateAiInsights = async ({
 
   if (generateAnomalies) {
     log.info(`Generating anomalous behavior data with ML jobs`);
-    await generateAnomalousBehaviorDataWithMlJobs(space, records, generateAnomalyData, v2);
+    await generateAnomalousBehaviorDataWithMlJobs(
+      space,
+      records,
+      generateAnomalyData,
+      v2,
+      correlateWithEntityStore,
+    );
   } else {
     log.info('Skipping anomalous behavior ML job and data generation due to --no-anomalies flag');
   }

--- a/src/commands/utils/entity_store.ts
+++ b/src/commands/utils/entity_store.ts
@@ -1,0 +1,157 @@
+import { getEntityStoreIndex } from '../../constants.ts';
+import { getEsClient } from './indices.ts';
+import { log } from '../../utils/logger.ts';
+
+export interface EntityHitSource {
+  '@timestamp'?: string;
+  entity?: {
+    id?: string;
+    name?: string;
+    type?: string;
+    EngineMetadata?: { UntypedId?: string };
+    risk?: {
+      calculated_level?: string;
+      calculated_score?: number;
+      calculated_score_norm?: number;
+    };
+    behaviors?: {
+      rule_names?: string[];
+      anomaly_job_ids?: string[];
+    };
+    relationships?: Record<string, string[]>;
+    attributes?: {
+      watchlists?: string[];
+      [key: string]: unknown;
+    };
+  };
+  user?: {
+    name?: string;
+    id?: string;
+    email?: string;
+    domain?: string;
+  };
+  host?: {
+    name?: string;
+    id?: string;
+  };
+  asset?: {
+    criticality?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface EntityHit {
+  _id: string;
+  _index: string;
+  _source: EntityHitSource;
+}
+
+export const fetchEntities = async (
+  count: number,
+  space?: string,
+  type: 'Identity' | 'Host' = 'Identity',
+): Promise<EntityHit[]> => {
+  if (count <= 0) return [];
+
+  const client = getEsClient();
+  const response = await client.search({
+    index: getEntityStoreIndex(space),
+    size: count,
+    sort: [{ '@timestamp': 'desc' }],
+    query: {
+      bool: {
+        filter: [{ term: { 'entity.type': type } }],
+      },
+    },
+  });
+
+  return (response.hits.hits ?? []) as EntityHit[];
+};
+
+// --- DED / Recent anomalies correlation (shared types + fetch + parse) ---
+
+export interface HostIdentityForDed {
+  id?: string;
+  name?: string;
+}
+
+export interface UserIdentityForDed {
+  displayLabel: string;
+  ecsArrays: Record<string, string[]>;
+}
+
+const parseUserHit = (hit: EntityHit): UserIdentityForDed | null => {
+  const src = hit._source;
+  const entityId = src.entity?.id;
+  if (typeof entityId !== 'string' || !entityId.startsWith('user:')) return null;
+  if (entityId.endsWith('@local')) return null;
+
+  const user = src.user;
+  const userName = user?.name;
+  const userId = user?.id;
+  const userEmail = user?.email;
+  const userDomain = user?.domain;
+
+  // Fallback: use entity.name when user.* fields aren't populated.
+  const entityName = src.entity?.name;
+  const effectiveName = userName ?? entityName;
+  if (!effectiveName && !userId && !userEmail) return null;
+
+  // event.module is the @-suffix of UntypedId (e.g. "alice@okta" → "okta").
+  const untypedId = src.entity?.EngineMetadata?.UntypedId ?? entityId.slice('user:'.length);
+  const atIdx = untypedId.lastIndexOf('@');
+  const eventModule = atIdx !== -1 ? untypedId.slice(atIdx + 1) : undefined;
+
+  const ecsArrays: Record<string, string[]> = {};
+  if (effectiveName) ecsArrays['user.name'] = [effectiveName];
+  if (userId) ecsArrays['user.id'] = [userId];
+  if (userEmail) ecsArrays['user.email'] = [userEmail];
+  if (userDomain) ecsArrays['user.domain'] = [userDomain];
+  if (eventModule) ecsArrays['event.module'] = [eventModule];
+
+  const displayLabel = effectiveName ?? userId ?? userEmail ?? 'user';
+  return { displayLabel, ecsArrays };
+};
+
+export const fetchHostIdentitiesForDed = async (
+  space: string,
+  count: number,
+): Promise<HostIdentityForDed[]> => {
+  const index = getEntityStoreIndex(space);
+  try {
+    const hits = await fetchEntities(count, space, 'Host');
+    const identities = hits
+      .map((h) => ({ id: h._source.host?.id, name: h._source.host?.name }))
+      .filter((h) => Boolean(h.id || h.name)) as HostIdentityForDed[];
+    log.info(
+      `Entity store correlation: read ${hits.length} host hit(s) from ${index}, parsed ${identities.length} usable host identity row(s).`,
+    );
+    return identities;
+  } catch (err) {
+    log.error(`Failed to read host entities from ${index}`, err);
+    throw err;
+  }
+};
+
+export const fetchUserIdentitiesForDed = async (
+  space: string,
+  count: number,
+): Promise<UserIdentityForDed[]> => {
+  const index = getEntityStoreIndex(space);
+  try {
+    const hits = await fetchEntities(count, space, 'Identity');
+    const identities: UserIdentityForDed[] = [];
+    for (const hit of hits) {
+      const parsed = parseUserHit(hit);
+      if (parsed) identities.push(parsed);
+    }
+    log.info(
+      `Entity store user correlation: read ${hits.length} Identity hit(s) from ${index}, parsed ${identities.length} usable user identity row(s).`,
+    );
+    return identities;
+  } catch (err) {
+    log.error(`Failed to read user entities from ${index}.`, err);
+    throw err;
+  }
+};


### PR DESCRIPTION
Adds a `--correlate-with-entity-store` flag to the `generate-entity-ai-insights` command. When set, generated DED ML anomaly records are correlated with real entities from the entity store, ensuring those entities appear in the `Recent Anomalies` table in Kibana's Entity Analytics page.

ps: I don't have much context about how this data actually works, so please let me know if this doesn't make sense.