### PR TITLE
Org data/add services

### DIFF
--- a/.agents/skills/update-org-data-integrations/SKILL.md
+++ b/.agents/skills/update-org-data-integrations/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   that extend BaseIntegration for the `yarn start org-data`
   (generate-correlated-organization-data) command. These classes define Fleet
   package installation, data stream configs, and generateDocuments() methods
-  that produce correlated user/device documents across the simulated
+  that produce correlated user/device/service documents across the simulated
   organization.
 
   Use ONLY when the user explicitly asks to add, update, or fix an integration
@@ -204,6 +204,20 @@ integration that references users:
 | `name`           | Server hostname                        | `api-server-prod-a1b2c3` |
 | `elasticAgentId` | Elastic Agent UUID for the server host | `d4e5f6a7-...`           |
 
+#### Stable fields on Service
+
+`org.services` is a catalog of platform services, SaaS apps, the org's identity provider, and (for medium / enterprise sizes) org-owned microservices. It's the source of truth for ECS `service.entity.id`. Generate services from `src/commands/org_data/data/services.ts` -- never invent service IDs in an integration.
+
+| Field             | Description                                                                     | Example                                           |
+| ----------------- | ------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `id`              | Service identifier matching the real eventSource / serviceName / SaaS app id    | `ec2.amazonaws.com`, `salesforce`, `checkout-api` |
+| `name`            | Display name                                                                    | `Amazon EC2`, `Salesforce`, `Checkout API`        |
+| `kind`            | One of `cloud_platform`, `saas_app`, `identity_provider`, `org_service`         | `cloud_platform`                                  |
+| `provider`        | Cloud provider (only on `cloud_platform`)                                       | `aws`                                             |
+| `entityId`        | Deterministic ECS `service.entity.id` value                                     | `service:cloud_platform:ec2.amazonaws.com`        |
+| `ownerEmployeeId` | Employee who owns the service (only on `org_service`, medium / enterprise orgs) | `<Employee.id>`                                   |
+| `hostIds`         | Hosts the service runs on (only on `org_service`, medium / enterprise orgs)     | `['<Host.id>', ...]`                              |
+
 #### CentralAgent on Organization
 
 The `org.centralAgent` represents a single Elastic Agent deployed on a central fleet
@@ -219,20 +233,21 @@ identity in their documents.
 
 When generating documents, map ECS fields to the stable Employee/Device values:
 
-| ECS Field       | Rule                                                                                                                                                                                                                         |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `user.id`       | Windows: `employee.windowsSid`. Mac/Linux: `String(employee.unixUid)`. **Never** generate random SIDs/UIDs per event.                                                                                                        |
-| `user.name`     | Always `employee.userName`.                                                                                                                                                                                                  |
-| `user.email`    | Always `employee.email`.                                                                                                                                                                                                     |
-| `user.domain`   | Windows user-context: derive from employee (e.g. `employee.userName.split('.')[0].toUpperCase()`). Use `'NT AUTHORITY'` only for SYSTEM.                                                                                     |
-| `host.id`       | Always `device.id`.                                                                                                                                                                                                          |
-| `host.name`     | `${employee.userName}-${device.platform}` for employee devices.                                                                                                                                                              |
-| `host.mac`      | Always `device.macAddress`. Convert separator as needed (dash for ECS/endpoint, colon for Jamf). **Never** call `faker.internet.mac()`.                                                                                      |
-| `host.ip`       | Always `device.ipAddress` as the primary IP. **Never** call `faker.internet.ipv4()` for host IPs. Random IPs are OK for `source.ip`, `destination.ip`, or `external_ip`.                                                     |
-| `agent.id`      | Local workstation: `device.elasticAgentId`. Server: `host.elasticAgentId`. Centralized cloud: `org.centralAgent.id`. Use `buildLocalAgent()`, `buildServerAgent()`, or `buildCentralAgent()` helpers from `BaseIntegration`. |
-| `agent.name`    | Local workstation: `${employee.userName}-${device.platform}` (same as `host.name`). Server: `host.name`. Centralized cloud: `org.centralAgent.name` (`fleet-collector-01`).                                                  |
-| `agent.type`    | `'endpoint'` for Elastic Defend, `'filebeat'` for all other integrations.                                                                                                                                                    |
-| `agent.version` | Always `ELASTIC_AGENT_VERSION` (`'8.17.4'`), exported from `base_integration.ts`.                                                                                                                                            |
+| ECS Field           | Rule                                                                                                                                                                                                                                                                                                                                     |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `user.id`           | Windows: `employee.windowsSid`. Mac/Linux: `String(employee.unixUid)`. **Never** generate random SIDs/UIDs per event.                                                                                                                                                                                                                    |
+| `user.name`         | Always `employee.userName`.                                                                                                                                                                                                                                                                                                              |
+| `user.email`        | Always `employee.email`.                                                                                                                                                                                                                                                                                                                 |
+| `user.domain`       | Windows user-context: derive from employee (e.g. `employee.userName.split('.')[0].toUpperCase()`). Use `'NT AUTHORITY'` only for SYSTEM.                                                                                                                                                                                                 |
+| `host.id`           | Always `device.id`.                                                                                                                                                                                                                                                                                                                      |
+| `host.name`         | `${employee.userName}-${device.platform}` for employee devices.                                                                                                                                                                                                                                                                          |
+| `host.mac`          | Always `device.macAddress`. Convert separator as needed (dash for ECS/endpoint, colon for Jamf). **Never** call `faker.internet.mac()`.                                                                                                                                                                                                  |
+| `host.ip`           | Always `device.ipAddress` as the primary IP. **Never** call `faker.internet.ipv4()` for host IPs. Random IPs are OK for `source.ip`, `destination.ip`, or `external_ip`.                                                                                                                                                                 |
+| `agent.id`          | Local workstation: `device.elasticAgentId`. Server: `host.elasticAgentId`. Centralized cloud: `org.centralAgent.id`. Use `buildLocalAgent()`, `buildServerAgent()`, or `buildCentralAgent()` helpers from `BaseIntegration`.                                                                                                             |
+| `agent.name`        | Local workstation: `${employee.userName}-${device.platform}` (same as `host.name`). Server: `host.name`. Centralized cloud: `org.centralAgent.name` (`fleet-collector-01`).                                                                                                                                                              |
+| `agent.type`        | `'endpoint'` for Elastic Defend, `'filebeat'` for all other integrations.                                                                                                                                                                                                                                                                |
+| `agent.version`     | Always `ELASTIC_AGENT_VERSION` (`'8.17.4'`), exported from `base_integration.ts`.                                                                                                                                                                                                                                                        |
+| `service.entity.id` | Look up by integration-specific identifier in `correlationMap.serviceIdToService` (e.g. CloudTrail `eventSource`, GCP `protoPayload.serviceName`, SaaS app id). For org-owned services, iterate `org.services` directly and use `service.entityId`. **Never** synthesize service entity IDs per event. See Step 3d for the full pattern. |
 
 #### When to extend the CorrelationMap
 
@@ -244,6 +259,11 @@ extend the correlation infrastructure:
 3. Add a new `Map` entry to the `CorrelationMap` interface in `src/commands/org_data/types.ts`
 4. Populate it in `buildCorrelationMap()` in `src/commands/org_data/correlation.ts`
 5. Add it to `createEmptyCorrelationMap()` in `src/commands/org_data/integrations/base_integration.ts`
+
+Service entities already use this pattern -- you do **not** need to repeat it for services. The
+existing maps `correlationMap.serviceIdToService` (keyed by service id, e.g. AWS eventSource or GCP
+serviceName), `serviceEntityIdToService`, and `hostIdToServices` are populated automatically for
+every org. Use them directly to resolve `service.entity.id`. See Step 3d.
 
 ### Step 3c: Produce Pre-Pipeline (Raw) Document Format
 
@@ -335,6 +355,123 @@ Some integrations do NOT have ingest pipelines or use non-standard flows:
 - **Cloud Asset Inventory**: No ingest pipeline. Produces documents in the asset inventory format.
 
 When in doubt, always check the pipeline YAML first.
+
+### Step 3d: Attach `service.entity.id` When Applicable
+
+ECS `service.entity.id` is used to correlate logs from the same service across data streams. The
+`org.services` catalog already models the services that exist in the simulated org (see Step 3b).
+Integrations should attach `service.entity.id` only when the events they emit clearly originate
+from a known service.
+
+Pattern depends on the data shape:
+
+#### Cloud platform audit logs (CloudTrail, GCP audit, Azure activitylogs)
+
+Each event names the platform service in a raw payload field. Look it up in
+`correlationMap.serviceIdToService` and attach `service.entity.id` to every doc. ECS `service.name`
+is still derived by the ingest pipeline from the raw payload (CloudTrail's `eventSource`, GCP's
+`protoPayload.serviceName`, Azure's `properties.resource_provider`), so do not pre-set it on the
+generator side.
+
+The recommended pattern adds a private map field on the integration class and a small helper:
+
+```typescript
+import { type Service, ... } from '../types.ts';
+
+export class CloudTrailIntegration extends BaseIntegration {
+  private serviceIdToService?: Map<string, Service>;
+
+  private serviceAttachmentFor(eventSource: string): { entity: { id: string } } | undefined {
+    const svc = this.serviceIdToService?.get(eventSource);
+    return svc ? { entity: { id: svc.entityId } } : undefined;
+  }
+
+  generateDocuments(org: Organization, correlationMap: CorrelationMap) {
+    this.serviceIdToService = correlationMap.serviceIdToService;
+    // ... emit docs ...
+  }
+
+  private createApiCallEvent(...) {
+    const service = this.serviceAttachmentFor(serviceConfig.eventSource);
+    return {
+      '@timestamp': timestamp,
+      message: JSON.stringify(rawEvent),
+      data_stream: { ... },
+      ...(service && { service }),
+    } as IntegrationDocument;
+  }
+}
+```
+
+See `src/commands/org_data/integrations/cloudtrail_integration.ts` for the full implementation
+and `src/commands/org_data/integrations/gcp_integration.ts` for the GCP audit variant.
+
+When the integration owns a fixed list of platform services (like GCP audit), source it from the
+shared catalog (`CLOUD_PLATFORM_SERVICES.<provider>` in `data/services.ts`) rather than redefining
+service IDs locally. Keep audit-specific data (method names, weights, etc.) in a separate map keyed
+by the catalog id.
+
+#### SaaS app sign-ins (Azure signinlogs, Okta SAML, GWS SAML)
+
+A fraction of sign-in events represent a SaaS app authenticating to the IdP rather than a user
+sign-in. Pick a SaaS service from `org.services.filter(s => s.kind === 'saas_app')`, inject the
+vendor-specific raw fields the pipeline expects so it can derive `service.name`, and attach
+`service.entity.id` directly on the doc.
+
+Example from `src/commands/org_data/integrations/azure_integration.ts` (signinlogs):
+
+```typescript
+const isServicePrincipalSignIn =
+  this.saasServices.length > 0 &&
+  faker.helpers.weightedArrayElement([
+    { value: true, weight: 25 },
+    { value: false, weight: 75 },
+  ]);
+const saasService = isServicePrincipalSignIn
+  ? faker.helpers.arrayElement(this.saasServices)
+  : undefined;
+
+// ...
+
+const rawAzureJson = {
+  // ...
+  properties: {
+    // ... user fields ...
+    ...(saasService && {
+      servicePrincipalName: saasService.name, // pipeline -> service.name
+      servicePrincipalId: saasService.id,
+    }),
+  },
+};
+
+return {
+  '@timestamp': timestamp,
+  message: JSON.stringify(rawAzureJson),
+  data_stream: { ... },
+  ...(saasService && { service: { entity: { id: saasService.entityId } } }),
+} as IntegrationDocument;
+```
+
+#### Pipeline-only integrations (namespaced `service.name`)
+
+Some integrations only populate a namespaced field like `google_workspace.admin.service.name`
+(not the top-level ECS `service.name`). For these, just include the raw field the pipeline
+renames -- e.g. a `SERVICE_NAME` parameter in `events.parameters` for Google Workspace admin --
+and do **not** attach a top-level `service.entity.id` (the namespaced field doesn't represent an
+ECS Service entity).
+
+See `src/commands/org_data/integrations/google_workspace_integration.ts:adminDoc()` for the
+example.
+
+#### When to skip
+
+Do **not** attach `service.entity.id` when:
+
+- The event isn't clearly attributable to a single service (e.g. a generic firewall log, an
+  endpoint process event).
+- The integration's `service.name` is namespaced (see previous section).
+
+When in doubt, leave it off rather than synthesizing entity IDs that wouldn't exist in real data.
 
 ### Step 4: Register the Integration (New Integrations Only)
 
@@ -452,7 +589,13 @@ Review and update the following sections if any of them changed:
 5. **Detection rules pattern** (Step 5) -- if the `DetectionRuleDefinition` interface or
    `INTEGRATION_DETECTION_RULES` structure changed, reflect it.
 
-6. **File locations table** -- if any paths moved or new key files were created, update the table
+6. **Service catalog and `service.entity.id` patterns** (Step 3b "Stable fields on Service" and
+   Step 3d) -- if the integration introduced a new SaaS app, cloud platform service, or org-service
+   template, add it to `src/commands/org_data/data/services.ts`. If the attachment pattern changed
+   or a new pattern emerged (beyond the cloud-platform / SaaS-sign-in / pipeline-only cases), add
+   a matching subsection to Step 3d.
+
+7. **File locations table** -- if any paths moved or new key files were created, update the table
    at the bottom.
 
 Only update sections where the session produced actual changes. Do not speculatively rewrite
@@ -470,6 +613,7 @@ unaffected sections.
 | Organization generator    | `src/commands/org_data/org_data_generator.ts`                         |
 | Correlation builder       | `src/commands/org_data/correlation.ts`                                |
 | Detection rules           | `src/commands/org_data/detection_rules.ts`                            |
+| Service catalog           | `src/commands/org_data/data/services.ts`                              |
 | Integrations repo         | `/Users/johndoe/repos/integrations/packages/`                         |
 | Beats repo                | `/Users/johndoe/repos/beats/x-pack/filebeat/module/`                  |
 | Endpoint-package repo     | `/Users/johndoe/repos/endpoint-package/`                              |

--- a/src/commands/org_data/correlation.ts
+++ b/src/commands/org_data/correlation.ts
@@ -31,6 +31,9 @@ export const buildCorrelationMap = (org: Organization): CorrelationMap => {
     jamfUdidToDevice: new Map(),
     adDnToEmployee: new Map(),
     windowsSidToEmployee: new Map(),
+    serviceIdToService: new Map(),
+    serviceEntityIdToService: new Map(),
+    hostIdToServices: new Map(),
   };
 
   // Build employee to Okta user correlations
@@ -95,6 +98,17 @@ export const buildCorrelationMap = (org: Organization): CorrelationMap => {
   // Build Windows SID to employee correlations
   for (const employee of org.employees) {
     correlationMap.windowsSidToEmployee.set(employee.windowsSid, employee);
+  }
+
+  // Build service correlations: id -> Service, entityId -> Service, hostId -> Service[]
+  for (const svc of org.services) {
+    correlationMap.serviceIdToService.set(svc.id, svc);
+    correlationMap.serviceEntityIdToService.set(svc.entityId, svc);
+    for (const hostId of svc.hostIds ?? []) {
+      const list = correlationMap.hostIdToServices.get(hostId) ?? [];
+      list.push(svc);
+      correlationMap.hostIdToServices.set(hostId, list);
+    }
   }
 
   return correlationMap;
@@ -191,6 +205,30 @@ export const verifyCorrelationIntegrity = (
     }
   }
 
+  // Service entity integrity: unique entityIds, valid owner/host references.
+  const serviceEntityIds = new Set<string>();
+  const employeeIds = new Set(org.employees.map((e) => e.id));
+  const hostIds = new Set(org.hosts.map((h) => h.id));
+  for (const svc of org.services) {
+    if (serviceEntityIds.has(svc.entityId)) {
+      errors.push(`Duplicate service entity ID: ${svc.entityId}`);
+    }
+    serviceEntityIds.add(svc.entityId);
+
+    if (svc.kind === 'org_service') {
+      if (svc.ownerEmployeeId && !employeeIds.has(svc.ownerEmployeeId)) {
+        errors.push(
+          `Org service ${svc.id} ownerEmployeeId=${svc.ownerEmployeeId} not found in employees`,
+        );
+      }
+      for (const hostId of svc.hostIds ?? []) {
+        if (!hostIds.has(hostId)) {
+          errors.push(`Org service ${svc.id} hostId=${hostId} not found in hosts`);
+        }
+      }
+    }
+  }
+
   return {
     valid: errors.length === 0,
     errors,
@@ -202,6 +240,10 @@ export const verifyCorrelationIntegrity = (
       serviceAccounts: org.cloudIamUsers.filter((u) => !u.isFederated).length,
       oktaGroups: org.oktaGroups.length,
       entraIdGroups: org.entraIdGroups.length,
+      services: org.services.length,
+      cloudPlatformServices: org.services.filter((s) => s.kind === 'cloud_platform').length,
+      saasApps: org.services.filter((s) => s.kind === 'saas_app').length,
+      orgServices: org.services.filter((s) => s.kind === 'org_service').length,
     },
   };
 };
@@ -220,6 +262,10 @@ export interface CorrelationVerificationResult {
     serviceAccounts: number;
     oktaGroups: number;
     entraIdGroups: number;
+    services: number;
+    cloudPlatformServices: number;
+    saasApps: number;
+    orgServices: number;
   };
 }
 
@@ -249,6 +295,9 @@ CrowdStrike Agent -> Device mappings: ${correlationMap.crowdstrikeAgentIdToDevic
 Jamf UDID -> Device mappings: ${correlationMap.jamfUdidToDevice.size}
 AD DN -> Employee mappings: ${correlationMap.adDnToEmployee.size}
 Windows SID -> Employee mappings: ${correlationMap.windowsSidToEmployee.size}
+Service ID -> Service mappings: ${correlationMap.serviceIdToService.size}
+Service EntityID -> Service mappings: ${correlationMap.serviceEntityIdToService.size}
+Host ID -> Services mappings: ${correlationMap.hostIdToServices.size}
 
 AWS Access Group: ${awsAccessGroup?.name || 'Not found'}
 Employees with AWS Access: ${awsEmployees.length}
@@ -259,6 +308,11 @@ Service Accounts: ${verification.stats.serviceAccounts}
 
 Okta Groups: ${verification.stats.oktaGroups}
 Entra ID Groups: ${verification.stats.entraIdGroups}
+
+Services: ${verification.stats.services}
+  - Cloud Platform: ${verification.stats.cloudPlatformServices}
+  - SaaS Apps: ${verification.stats.saasApps}
+  - Org-Owned: ${verification.stats.orgServices}
 
 Verification: ${verification.valid ? '✓ PASSED' : '✗ FAILED'}
 ${verification.errors.length > 0 ? `Errors:\n  - ${verification.errors.join('\n  - ')}` : ''}

--- a/src/commands/org_data/data/services.ts
+++ b/src/commands/org_data/data/services.ts
@@ -1,0 +1,224 @@
+/**
+ * Service catalog: platform services, SaaS apps, and org-owned microservice
+ * templates used by `generateServices()` in `org_data_generator.ts`.
+ *
+ * Cloud platform service identifiers mirror the actual eventSource / serviceName
+ * strings emitted by AWS CloudTrail, GCP Audit Logs, and Azure Activity Logs so
+ * the cloudtrail/gcp/azure integrations can look services up by these IDs.
+ */
+
+import { type CloudProvider, type ProductivitySuite, type ServiceKind } from '../types.ts';
+
+/**
+ * Template used to seed `Service` entities in the org. The generator decorates
+ * these with `entityId` and (for org_service) `ownerEmployeeId` / `hostIds`.
+ */
+export interface ServiceTemplate {
+  id: string;
+  name: string;
+  kind: ServiceKind;
+  provider?: CloudProvider;
+}
+
+/**
+ * Cloud platform services keyed by provider. The `id` matches the actual
+ * eventSource string emitted by each provider's audit log so a single Map
+ * lookup by eventSource resolves the service entity at integration time.
+ */
+export const CLOUD_PLATFORM_SERVICES: Record<CloudProvider, ServiceTemplate[]> = {
+  aws: [
+    { id: 'ec2.amazonaws.com', name: 'Amazon EC2', kind: 'cloud_platform', provider: 'aws' },
+    { id: 's3.amazonaws.com', name: 'Amazon S3', kind: 'cloud_platform', provider: 'aws' },
+    { id: 'rds.amazonaws.com', name: 'Amazon RDS', kind: 'cloud_platform', provider: 'aws' },
+    { id: 'lambda.amazonaws.com', name: 'AWS Lambda', kind: 'cloud_platform', provider: 'aws' },
+    { id: 'iam.amazonaws.com', name: 'AWS IAM', kind: 'cloud_platform', provider: 'aws' },
+    { id: 'sts.amazonaws.com', name: 'AWS STS', kind: 'cloud_platform', provider: 'aws' },
+    {
+      id: 'cloudtrail.amazonaws.com',
+      name: 'AWS CloudTrail',
+      kind: 'cloud_platform',
+      provider: 'aws',
+    },
+    { id: 'kms.amazonaws.com', name: 'AWS KMS', kind: 'cloud_platform', provider: 'aws' },
+    {
+      id: 'ssm.amazonaws.com',
+      name: 'AWS Systems Manager',
+      kind: 'cloud_platform',
+      provider: 'aws',
+    },
+    {
+      id: 'ec2-instance-connect.amazonaws.com',
+      name: 'AWS EC2 Instance Connect',
+      kind: 'cloud_platform',
+      provider: 'aws',
+    },
+    {
+      id: 'signin.amazonaws.com',
+      name: 'AWS Console Sign-in',
+      kind: 'cloud_platform',
+      provider: 'aws',
+    },
+  ],
+  gcp: [
+    {
+      id: 'compute.googleapis.com',
+      name: 'Compute Engine',
+      kind: 'cloud_platform',
+      provider: 'gcp',
+    },
+    {
+      id: 'storage.googleapis.com',
+      name: 'Cloud Storage',
+      kind: 'cloud_platform',
+      provider: 'gcp',
+    },
+    { id: 'iam.googleapis.com', name: 'Cloud IAM', kind: 'cloud_platform', provider: 'gcp' },
+    {
+      id: 'cloudresourcemanager.googleapis.com',
+      name: 'Resource Manager',
+      kind: 'cloud_platform',
+      provider: 'gcp',
+    },
+    { id: 'bigquery.googleapis.com', name: 'BigQuery', kind: 'cloud_platform', provider: 'gcp' },
+    {
+      id: 'container.googleapis.com',
+      name: 'Kubernetes Engine',
+      kind: 'cloud_platform',
+      provider: 'gcp',
+    },
+    { id: 'sqladmin.googleapis.com', name: 'Cloud SQL', kind: 'cloud_platform', provider: 'gcp' },
+    {
+      id: 'logging.googleapis.com',
+      name: 'Cloud Logging',
+      kind: 'cloud_platform',
+      provider: 'gcp',
+    },
+  ],
+  azure: [
+    { id: 'Microsoft.Compute', name: 'Azure Compute', kind: 'cloud_platform', provider: 'azure' },
+    { id: 'Microsoft.Storage', name: 'Azure Storage', kind: 'cloud_platform', provider: 'azure' },
+    {
+      id: 'Microsoft.KeyVault',
+      name: 'Azure Key Vault',
+      kind: 'cloud_platform',
+      provider: 'azure',
+    },
+    { id: 'Microsoft.Sql', name: 'Azure SQL', kind: 'cloud_platform', provider: 'azure' },
+    { id: 'Microsoft.Network', name: 'Azure Network', kind: 'cloud_platform', provider: 'azure' },
+    {
+      id: 'Microsoft.Authorization',
+      name: 'Azure RBAC',
+      kind: 'cloud_platform',
+      provider: 'azure',
+    },
+  ],
+};
+
+/**
+ * SaaS apps every modeled org subscribes to. These are the apps that appear
+ * as service principals in Azure sign-in logs and SAML applications in
+ * Google Workspace SAML logs.
+ */
+export const SAAS_APP_CATALOG: ServiceTemplate[] = [
+  { id: 'salesforce', name: 'Salesforce', kind: 'saas_app' },
+  { id: 'github', name: 'GitHub Enterprise', kind: 'saas_app' },
+  { id: 'slack', name: 'Slack', kind: 'saas_app' },
+  { id: 'zoom', name: 'Zoom', kind: 'saas_app' },
+  { id: 'snowflake', name: 'Snowflake', kind: 'saas_app' },
+  { id: 'atlassian', name: 'Atlassian Cloud', kind: 'saas_app' },
+  { id: 'servicenow', name: 'ServiceNow', kind: 'saas_app' },
+  { id: 'workday', name: 'Workday', kind: 'saas_app' },
+  { id: 'box', name: 'Box', kind: 'saas_app' },
+];
+
+/**
+ * Productivity-suite SaaS app. Swaps based on `productivitySuite`.
+ */
+export const PRODUCTIVITY_SAAS_APPS: Record<ProductivitySuite, ServiceTemplate> = {
+  microsoft: { id: 'microsoft-365', name: 'Microsoft 365', kind: 'saas_app' },
+  google: { id: 'google-workspace', name: 'Google Workspace', kind: 'saas_app' },
+};
+
+/**
+ * Identity provider templates. Org gets exactly one identity provider service,
+ * matched to the productivity suite by convention (Entra ID + M365, Okta + Google).
+ */
+export const IDP_TEMPLATES: Record<ProductivitySuite, ServiceTemplate> = {
+  microsoft: { id: 'entra_id', name: 'Microsoft Entra ID', kind: 'identity_provider' },
+  google: { id: 'okta', name: 'Okta', kind: 'identity_provider' },
+};
+
+/**
+ * Org-owned microservice templates. Only instantiated for medium/enterprise orgs.
+ * `ownedByDepartment` hints at the team that owns the service so the generator
+ * can pick a sensible owner employee.
+ */
+export interface OrgServiceTemplate extends ServiceTemplate {
+  kind: 'org_service';
+  ownedByDepartment: 'Product & Engineering' | 'Operations';
+}
+
+export const ORG_SERVICE_TEMPLATES: OrgServiceTemplate[] = [
+  {
+    id: 'checkout-api',
+    name: 'Checkout API',
+    kind: 'org_service',
+    ownedByDepartment: 'Product & Engineering',
+  },
+  {
+    id: 'payments-svc',
+    name: 'Payments Service',
+    kind: 'org_service',
+    ownedByDepartment: 'Product & Engineering',
+  },
+  {
+    id: 'auth-gateway',
+    name: 'Auth Gateway',
+    kind: 'org_service',
+    ownedByDepartment: 'Product & Engineering',
+  },
+  {
+    id: 'data-pipeline',
+    name: 'Data Pipeline',
+    kind: 'org_service',
+    ownedByDepartment: 'Product & Engineering',
+  },
+  {
+    id: 'notification-svc',
+    name: 'Notification Service',
+    kind: 'org_service',
+    ownedByDepartment: 'Product & Engineering',
+  },
+  {
+    id: 'monitoring-platform',
+    name: 'Monitoring Platform',
+    kind: 'org_service',
+    ownedByDepartment: 'Operations',
+  },
+  {
+    id: 'vpn-gateway',
+    name: 'VPN Gateway',
+    kind: 'org_service',
+    ownedByDepartment: 'Operations',
+  },
+  {
+    id: 'internal-portal',
+    name: 'Internal Portal',
+    kind: 'org_service',
+    ownedByDepartment: 'Operations',
+  },
+];
+
+/**
+ * Build a deterministic entity ID for a service. The format mirrors the
+ * convention used elsewhere for typed entities (user.entity.id / host.entity.id):
+ * `service:<kind>:<id>` for global services, with `@<orgname>` appended for
+ * org-owned services so two different orgs don't collide on `checkout-api`.
+ */
+export const buildServiceEntityId = (kind: ServiceKind, id: string, orgName: string): string => {
+  if (kind === 'org_service') {
+    const suffix = orgName.toLowerCase().replace(/\s+/g, '-');
+    return `service:org_service:${id}@${suffix}`;
+  }
+  return `service:${kind}:${id}`;
+};

--- a/src/commands/org_data/data/services.ts
+++ b/src/commands/org_data/data/services.ts
@@ -215,9 +215,15 @@ export const ORG_SERVICE_TEMPLATES: OrgServiceTemplate[] = [
  * `service:<kind>:<id>` for global services, with `@<orgname>` appended for
  * org-owned services so two different orgs don't collide on `checkout-api`.
  */
+const sanitizeOrgNameForEntityId = (orgName: string): string =>
+  orgName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
 export const buildServiceEntityId = (kind: ServiceKind, id: string, orgName: string): string => {
   if (kind === 'org_service') {
-    const suffix = orgName.toLowerCase().replace(/\s+/g, '-');
+    const suffix = sanitizeOrgNameForEntityId(orgName);
     return `service:org_service:${id}@${suffix}`;
   }
   return `service:${kind}:${id}`;

--- a/src/commands/org_data/integrations/azure_integration.ts
+++ b/src/commands/org_data/integrations/azure_integration.ts
@@ -12,7 +12,13 @@ import {
   type IntegrationDocument,
   type DataStreamConfig,
 } from './base_integration.ts';
-import { type Organization, type Employee, type Device, type CorrelationMap } from '../types.ts';
+import {
+  type Organization,
+  type Employee,
+  type Device,
+  type CorrelationMap,
+  type Service,
+} from '../types.ts';
 import { faker } from '@faker-js/faker';
 
 const AZURE_RESOURCE_OPERATIONS: Array<{
@@ -306,10 +312,18 @@ export class AzureIntegration extends BaseIntegration {
     { name: 'Spring Cloud Logs', index: 'logs-azure.springcloudlogs-default' },
   ];
 
+  /**
+   * SaaS app services from the org catalog. Used to populate
+   * `properties.servicePrincipalName/Id` on a fraction of sign-in logs so the
+   * azure.signinlogs ingest pipeline can map them to ECS `service.name`.
+   */
+  private saasServices: Service[] = [];
+
   generateDocuments(
     org: Organization,
     _correlationMap: CorrelationMap,
   ): Map<string, IntegrationDocument[]> {
+    this.saasServices = org.services.filter((s) => s.kind === 'saas_app');
     const documentsMap = new Map<string, IntegrationDocument[]>();
     const tenantId = faker.string.uuid();
     const subscriptionId = faker.string.uuid().toUpperCase();
@@ -573,7 +587,21 @@ export class AzureIntegration extends BaseIntegration {
     centralAgent: { id: string; name: string; type: string; version: string },
   ): IntegrationDocument {
     const timestamp = this.getRandomTimestamp(72);
-    const app = faker.helpers.arrayElement(SIGNIN_APPS);
+    // ~25% of sign-ins represent a service principal (SaaS app) authenticating
+    // to the tenant. Those carry servicePrincipalName/Id so the ingest pipeline
+    // can populate ECS service.name on the resulting document.
+    const isServicePrincipalSignIn =
+      this.saasServices.length > 0 &&
+      faker.helpers.weightedArrayElement([
+        { value: true, weight: 25 },
+        { value: false, weight: 75 },
+      ]);
+    const saasService = isServicePrincipalSignIn
+      ? faker.helpers.arrayElement(this.saasServices)
+      : undefined;
+    const app = saasService
+      ? { name: saasService.name, id: faker.string.uuid() }
+      : faker.helpers.arrayElement(SIGNIN_APPS);
     const correlationId = faker.string.uuid();
     const clientIp = faker.internet.ipv4();
     const isInteractive = faker.helpers.weightedArrayElement([
@@ -655,6 +683,10 @@ export class AzureIntegration extends BaseIntegration {
         userDisplayName: displayName,
         userId: employee.entraIdUserId,
         userPrincipalName: employee.email,
+        ...(saasService && {
+          servicePrincipalName: saasService.name,
+          servicePrincipalId: saasService.id,
+        }),
       },
     };
 
@@ -663,6 +695,7 @@ export class AzureIntegration extends BaseIntegration {
       agent: centralAgent,
       message: JSON.stringify(rawAzureJson),
       data_stream: { dataset: 'azure.signinlogs', namespace: 'default', type: 'logs' },
+      ...(saasService && { service: { entity: { id: saasService.entityId } } }),
     } as IntegrationDocument;
   }
 

--- a/src/commands/org_data/integrations/azure_integration.ts
+++ b/src/commands/org_data/integrations/azure_integration.ts
@@ -600,7 +600,7 @@ export class AzureIntegration extends BaseIntegration {
       ? faker.helpers.arrayElement(this.saasServices)
       : undefined;
     const app = saasService
-      ? { name: saasService.name, id: faker.string.uuid() }
+      ? { name: saasService.name, id: saasService.id }
       : faker.helpers.arrayElement(SIGNIN_APPS);
     const correlationId = faker.string.uuid();
     const clientIp = faker.internet.ipv4();

--- a/src/commands/org_data/integrations/base_integration.ts
+++ b/src/commands/org_data/integrations/base_integration.ts
@@ -261,4 +261,7 @@ export const createEmptyCorrelationMap = (): CorrelationMap => ({
   jamfUdidToDevice: new Map(),
   adDnToEmployee: new Map(),
   windowsSidToEmployee: new Map(),
+  serviceIdToService: new Map(),
+  serviceEntityIdToService: new Map(),
+  hostIdToServices: new Map(),
 });

--- a/src/commands/org_data/integrations/cloudtrail_integration.ts
+++ b/src/commands/org_data/integrations/cloudtrail_integration.ts
@@ -16,6 +16,7 @@ import {
   type CloudAccount,
   type Employee,
   type Host,
+  type Service,
 } from '../types.ts';
 import { faker } from '@faker-js/faker';
 
@@ -173,12 +174,31 @@ export class CloudTrailIntegration extends BaseIntegration {
   ];
 
   /**
+   * Lookup of cloud platform services by id (eventSource). Set in
+   * generateDocuments so doc factories can resolve service.entity.id without
+   * threading correlationMap through every helper.
+   */
+  private serviceIdToService?: Map<string, Service>;
+
+  /**
+   * Resolve a service.entity.id attachment for a given CloudTrail eventSource.
+   * Returns `undefined` if the service catalog isn't populated (correlation
+   * map missing) or the eventSource isn't a known platform service, so callers
+   * can spread the result without adding noise to documents.
+   */
+  private serviceAttachmentFor(eventSource: string): { entity: { id: string } } | undefined {
+    const svc = this.serviceIdToService?.get(eventSource);
+    return svc ? { entity: { id: svc.entityId } } : undefined;
+  }
+
+  /**
    * Generate all CloudTrail documents
    */
   generateDocuments(
     org: Organization,
     correlationMap: CorrelationMap,
   ): Map<string, IntegrationDocument[]> {
+    this.serviceIdToService = correlationMap.serviceIdToService;
     const documentsMap = new Map<string, IntegrationDocument[]>();
     const documents: IntegrationDocument[] = [];
 
@@ -546,6 +566,7 @@ export class CloudTrailIntegration extends BaseIntegration {
       recipientAccountId: account.id,
     };
 
+    const service = this.serviceAttachmentFor('ssm.amazonaws.com');
     return {
       '@timestamp': timestamp,
       message: JSON.stringify(rawEvent),
@@ -560,6 +581,7 @@ export class CloudTrailIntegration extends BaseIntegration {
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
       user: { entity: { id: assumedRoleArn } },
       host: { id: host.id, name: host.name },
+      ...(service && { service }),
     } as IntegrationDocument;
   }
 
@@ -617,12 +639,14 @@ export class CloudTrailIntegration extends BaseIntegration {
       recipientAccountId: account.id,
     };
 
+    const service = this.serviceAttachmentFor('sts.amazonaws.com');
     return {
       '@timestamp': timestamp,
       agent: this.buildCentralAgent(org),
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      ...(service && { service }),
     } as IntegrationDocument;
   }
 
@@ -679,12 +703,14 @@ export class CloudTrailIntegration extends BaseIntegration {
       recipientAccountId: account.id,
     };
 
+    const service = this.serviceAttachmentFor('sts.amazonaws.com');
     return {
       '@timestamp': timestamp,
       agent: this.buildCentralAgent(org),
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      ...(service && { service }),
     } as IntegrationDocument;
   }
 
@@ -762,12 +788,14 @@ export class CloudTrailIntegration extends BaseIntegration {
       recipientAccountId: account.id,
     };
 
+    const serviceAttachment = this.serviceAttachmentFor(serviceConfig.eventSource);
     return {
       '@timestamp': timestamp,
       agent: this.buildCentralAgent(org),
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      ...(serviceAttachment && { service: serviceAttachment }),
     } as IntegrationDocument;
   }
 
@@ -818,12 +846,14 @@ export class CloudTrailIntegration extends BaseIntegration {
       recipientAccountId: account.id,
     };
 
+    const serviceAttachment = this.serviceAttachmentFor(serviceConfig.eventSource);
     return {
       '@timestamp': timestamp,
       agent: this.buildCentralAgent(org),
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      ...(serviceAttachment && { service: serviceAttachment }),
     } as IntegrationDocument;
   }
 
@@ -888,12 +918,14 @@ export class CloudTrailIntegration extends BaseIntegration {
       rawEvent.errorMessage = 'Failed authentication';
     }
 
+    const service = this.serviceAttachmentFor('signin.amazonaws.com');
     return {
       '@timestamp': timestamp,
       agent: this.buildCentralAgent(org),
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      ...(service && { service }),
     } as IntegrationDocument;
   }
 
@@ -931,11 +963,13 @@ export class CloudTrailIntegration extends BaseIntegration {
       recipientAccountId: account.id,
     };
 
+    const service = this.serviceAttachmentFor(hostTargetEvent.eventSource);
     return {
       '@timestamp': timestamp,
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      ...(service && { service }),
     } as IntegrationDocument;
   }
 

--- a/src/commands/org_data/integrations/gcp_integration.ts
+++ b/src/commands/org_data/integrations/gcp_integration.ts
@@ -14,16 +14,18 @@ import {
   type DataStreamConfig,
   type AgentData,
 } from './base_integration.ts';
-import { type Organization, type Employee, type CorrelationMap } from '../types.ts';
+import { type Organization, type Employee, type CorrelationMap, type Service } from '../types.ts';
+import { CLOUD_PLATFORM_SERVICES } from '../data/services.ts';
 import { faker } from '@faker-js/faker';
 
-const GCP_SERVICES: Array<{
-  serviceName: string;
-  methods: string[];
-  weight: number;
-}> = [
-  {
-    serviceName: 'compute.googleapis.com',
+/**
+ * GCP-specific audit method names + relative weights, keyed by the
+ * `serviceName` (== `id` in the shared catalog). The catalog is the source
+ * of truth for *which* GCP services exist; this map only contributes the
+ * audit-log-specific behavior the catalog doesn't model.
+ */
+const GCP_AUDIT_METHODS: Record<string, { methods: string[]; weight: number }> = {
+  'compute.googleapis.com': {
     methods: [
       'beta.compute.instances.aggregatedList',
       'v1.compute.instances.list',
@@ -34,8 +36,7 @@ const GCP_SERVICES: Array<{
     ],
     weight: 25,
   },
-  {
-    serviceName: 'storage.googleapis.com',
+  'storage.googleapis.com': {
     methods: [
       'storage.buckets.list',
       'storage.buckets.get',
@@ -44,8 +45,7 @@ const GCP_SERVICES: Array<{
     ],
     weight: 20,
   },
-  {
-    serviceName: 'iam.googleapis.com',
+  'iam.googleapis.com': {
     methods: [
       'google.iam.admin.v1.ListServiceAccounts',
       'google.iam.admin.v1.GetServiceAccount',
@@ -54,13 +54,11 @@ const GCP_SERVICES: Array<{
     ],
     weight: 15,
   },
-  {
-    serviceName: 'cloudresourcemanager.googleapis.com',
+  'cloudresourcemanager.googleapis.com': {
     methods: ['GetProject', 'ListProjects', 'GetIamPolicy', 'SetIamPolicy'],
     weight: 10,
   },
-  {
-    serviceName: 'bigquery.googleapis.com',
+  'bigquery.googleapis.com': {
     methods: [
       'google.cloud.bigquery.v2.JobService.InsertJob',
       'google.cloud.bigquery.v2.JobService.GetQueryResults',
@@ -68,28 +66,45 @@ const GCP_SERVICES: Array<{
     ],
     weight: 10,
   },
-  {
-    serviceName: 'container.googleapis.com',
+  'container.googleapis.com': {
     methods: [
       'google.container.v1.ClusterManager.ListClusters',
       'google.container.v1.ClusterManager.GetCluster',
     ],
     weight: 8,
   },
-  {
-    serviceName: 'sqladmin.googleapis.com',
+  'sqladmin.googleapis.com': {
     methods: ['cloudsql.instances.list', 'cloudsql.instances.get'],
     weight: 5,
   },
-  {
-    serviceName: 'logging.googleapis.com',
+  'logging.googleapis.com': {
     methods: [
       'google.logging.v2.LoggingServiceV2.ListLogEntries',
       'google.logging.v2.ConfigServiceV2.ListSinks',
     ],
     weight: 7,
   },
-];
+};
+
+/**
+ * Compose the audit-emitting GCP service list from the shared catalog,
+ * decorating each entry with audit-specific methods/weight. Only catalog
+ * services that have a method definition contribute audit logs.
+ */
+const buildGcpAuditServices = (): Array<{
+  serviceName: string;
+  methods: string[];
+  weight: number;
+}> =>
+  CLOUD_PLATFORM_SERVICES.gcp
+    .filter((tpl) => GCP_AUDIT_METHODS[tpl.id])
+    .map((tpl) => ({
+      serviceName: tpl.id,
+      methods: GCP_AUDIT_METHODS[tpl.id].methods,
+      weight: GCP_AUDIT_METHODS[tpl.id].weight,
+    }));
+
+const GCP_AUDIT_SERVICES = buildGcpAuditServices();
 
 const GCP_REGIONS = [
   'us-central1',
@@ -169,10 +184,17 @@ export class GcpIntegration extends BaseIntegration {
     { name: 'firewall', index: 'logs-gcp.firewall-default' },
   ];
 
+  /**
+   * Lookup of cloud platform services by id (eventSource / serviceName).
+   * Set in generateDocuments so doc factories can resolve service.entity.id.
+   */
+  private serviceIdToService?: Map<string, Service>;
+
   generateDocuments(
     org: Organization,
-    _correlationMap: CorrelationMap,
+    correlationMap: CorrelationMap,
   ): Map<string, IntegrationDocument[]> {
+    this.serviceIdToService = correlationMap.serviceIdToService;
     const documentsMap = new Map<string, IntegrationDocument[]>();
     const centralAgent = this.buildCentralAgent(org);
     const auditDocs: IntegrationDocument[] = [];
@@ -205,7 +227,7 @@ export class GcpIntegration extends BaseIntegration {
     centralAgent: AgentData,
   ): IntegrationDocument {
     const service = faker.helpers.weightedArrayElement(
-      GCP_SERVICES.map((s) => ({ value: s, weight: s.weight })),
+      GCP_AUDIT_SERVICES.map((s) => ({ value: s, weight: s.weight })),
     );
     const methodName = faker.helpers.arrayElement(service.methods);
     const timestamp = this.getRandomTimestamp(72);
@@ -263,11 +285,13 @@ export class GcpIntegration extends BaseIntegration {
       receiveTimestamp,
     };
 
+    const serviceEntity = this.serviceIdToService?.get(service.serviceName);
     return {
       '@timestamp': timestamp,
       agent: centralAgent,
       message: JSON.stringify(rawGcpLogEntry),
       data_stream: { namespace: 'default', type: 'logs', dataset: 'gcp.audit' },
+      ...(serviceEntity && { service: { entity: { id: serviceEntity.entityId } } }),
     } as IntegrationDocument;
   }
 

--- a/src/commands/org_data/integrations/google_workspace_integration.ts
+++ b/src/commands/org_data/integrations/google_workspace_integration.ts
@@ -242,11 +242,26 @@ export class GoogleWorkspaceIntegration extends BaseIntegration {
   private adminDoc(employee: Employee, org: Organization): IntegrationDocument {
     const cfg = GOOGLE_WORKSPACE_SERVICES.admin;
     const eventAction = faker.helpers.arrayElement(cfg.events);
+    // SERVICE_NAME identifies the Google Workspace admin service touched by the
+    // event. The integration's admin pipeline renames this parameter to
+    // `google_workspace.admin.service.name`, so it must be one of the values
+    // Google emits in real admin reports.
+    const serviceName = faker.helpers.arrayElement([
+      'admin_console',
+      'directory',
+      'drive',
+      'gmail',
+      'security',
+      'mobile',
+      'classroom',
+      'data_studio',
+    ]);
     return this.rawActivityDoc('admin', 'admin', employee, org, {
       name: eventAction,
       type: eventAction.includes('SETTING') ? 'APPLICATION_SETTINGS' : 'USER_SETTINGS',
       parameters: [
         param('APPLICATION_NAME', faker.helpers.arrayElement(cfg.applications)),
+        param('SERVICE_NAME', serviceName),
         param('SETTING_NAME', eventAction.toLowerCase().replace(/_/g, ' ')),
         param('OLD_VALUE', faker.helpers.arrayElement(['true', 'false', 'enabled', 'disabled'])),
         param('NEW_VALUE', faker.helpers.arrayElement(['true', 'false', 'enabled', 'disabled'])),

--- a/src/commands/org_data/org_data_generator.ts
+++ b/src/commands/org_data/org_data_generator.ts
@@ -28,6 +28,7 @@ import {
   type OrganizationSize,
   SIZE_CONFIGS,
   type DepartmentName,
+  type Service,
 } from './types.ts';
 import { DEPARTMENTS, getCloudAccessDepartments } from './data/departments.ts';
 import { getRandomCountry, getRandomCity } from './data/countries.ts';
@@ -37,6 +38,16 @@ import {
   IAM_ROLE_NAMES,
   SERVICE_NAMES,
 } from './data/cloud_resources.ts';
+import {
+  CLOUD_PLATFORM_SERVICES,
+  SAAS_APP_CATALOG,
+  PRODUCTIVITY_SAAS_APPS,
+  IDP_TEMPLATES,
+  ORG_SERVICE_TEMPLATES,
+  buildServiceEntityId,
+  type OrgServiceTemplate,
+  type ServiceTemplate,
+} from './data/services.ts';
 
 /**
  * Generate a complete organization based on configuration
@@ -102,6 +113,17 @@ export const generateOrgData = (config: OrganizationConfig): Organization => {
   // Determine productivity suite
   const productivitySuite: ProductivitySuite = config.productivitySuite || 'microsoft';
 
+  // Generate services (cloud platform, SaaS, IdP, org-owned microservices).
+  // Must run after employees + hosts are generated since org services attach to both.
+  const services = generateServices(
+    config.name,
+    sizeConfig.cloudProviders,
+    productivitySuite,
+    config.size,
+    employees,
+    hosts,
+  );
+
   // Generate central agent for cloud/SaaS integrations
   const centralAgent: CentralAgent = {
     id: faker.string.uuid(),
@@ -123,6 +145,7 @@ export const generateOrgData = (config: OrganizationConfig): Organization => {
     githubOrg,
     cloudflareZones,
     onePasswordVaults,
+    services,
     productivitySuite,
     centralAgent,
   };
@@ -858,6 +881,72 @@ const generateOnePasswordVaults = (): OnePasswordVault[] => {
 };
 
 /**
+ * Generate the org's service catalog: cloud platform services, SaaS apps,
+ * the identity provider, and (for medium/enterprise sizes) org-owned services.
+ *
+ * Org services pick a random owner from the appropriate department and attach
+ * to 1-3 hosts so cross-integration correlation (host -> services) works.
+ */
+const generateServices = (
+  orgName: string,
+  cloudProviders: CloudProvider[],
+  productivitySuite: ProductivitySuite,
+  size: OrganizationSize,
+  employees: Employee[],
+  hosts: Host[],
+): Service[] => {
+  const services: Service[] = [];
+
+  const fromTemplate = (tpl: ServiceTemplate): Service => ({
+    id: tpl.id,
+    name: tpl.name,
+    kind: tpl.kind,
+    provider: tpl.provider,
+    entityId: buildServiceEntityId(tpl.kind, tpl.id, orgName),
+  });
+
+  // Cloud platform services for every provider in scope.
+  for (const provider of cloudProviders) {
+    for (const tpl of CLOUD_PLATFORM_SERVICES[provider]) {
+      services.push(fromTemplate(tpl));
+    }
+  }
+
+  // SaaS apps (always present), plus the productivity-suite SaaS app.
+  for (const tpl of SAAS_APP_CATALOG) {
+    services.push(fromTemplate(tpl));
+  }
+  services.push(fromTemplate(PRODUCTIVITY_SAAS_APPS[productivitySuite]));
+
+  // Identity provider (one per org, follows productivity suite).
+  services.push(fromTemplate(IDP_TEMPLATES[productivitySuite]));
+
+  // Org-owned microservices only at medium/enterprise sizes.
+  if (size === 'medium' || size === 'enterprise') {
+    const orgServiceTemplates: OrgServiceTemplate[] =
+      size === 'medium' ? ORG_SERVICE_TEMPLATES.slice(0, 4) : ORG_SERVICE_TEMPLATES;
+
+    for (const tpl of orgServiceTemplates) {
+      const candidates = employees.filter((e) => e.department === tpl.ownedByDepartment);
+      const owner = candidates.length > 0 ? faker.helpers.arrayElement(candidates) : undefined;
+      const hostCount = Math.min(hosts.length, faker.number.int({ min: 1, max: 3 }));
+      const assignedHosts = hosts.length > 0 ? faker.helpers.arrayElements(hosts, hostCount) : [];
+
+      services.push({
+        id: tpl.id,
+        name: tpl.name,
+        kind: tpl.kind,
+        ownerEmployeeId: owner?.id,
+        hostIds: assignedHosts.map((h) => h.id),
+        entityId: buildServiceEntityId(tpl.kind, tpl.id, orgName),
+      });
+    }
+  }
+
+  return services;
+};
+
+/**
  * Get employee count for a given size
  */
 export const getEmployeeCountForSize = (size: OrganizationSize, seed?: number): number => {
@@ -925,6 +1014,12 @@ Cloudflare Zones: ${org.cloudflareZones.length}
   - Domains: ${org.cloudflareZones.map((z) => z.name).join(', ')}
 
 1Password Vaults: ${org.onePasswordVaults.length}
+
+Services: ${org.services.length}
+  - Cloud Platform: ${org.services.filter((s) => s.kind === 'cloud_platform').length}
+  - SaaS Apps: ${org.services.filter((s) => s.kind === 'saas_app').length}
+  - Identity Provider: ${org.services.filter((s) => s.kind === 'identity_provider').length}
+  - Org-Owned: ${org.services.filter((s) => s.kind === 'org_service').length}
 
 Productivity Suite: ${org.productivitySuite === 'microsoft' ? 'Microsoft 365' : 'Google Workspace'}
 `.trim();

--- a/src/commands/org_data/types.ts
+++ b/src/commands/org_data/types.ts
@@ -119,6 +119,38 @@ export interface CloudAccount {
 }
 
 /**
+ * Service entity kind. Distinguishes the four classes of services we model
+ * across the org so each integration can pick the right slice (cloud audit,
+ * SaaS auth, IdP, microservice telemetry).
+ */
+export type ServiceKind =
+  | 'cloud_platform' // Vendor-provided cloud APIs invoked by users (ec2.amazonaws.com)
+  | 'saas_app' // SaaS applications federated via the IdP (Salesforce, GitHub)
+  | 'identity_provider' // The org's IdP itself (Okta or Entra ID)
+  | 'org_service'; // Org-owned services/microservices (checkout-api, payments-svc)
+
+/**
+ * Service entity in the organization. Modeled as a peer to Employee/Device/Host
+ * so integrations can populate ECS service.* and service.entity.id consistently.
+ *
+ * - cloud_platform: id is the vendor service identifier (e.g. 'ec2.amazonaws.com').
+ * - saas_app: id is the SaaS app slug (e.g. 'salesforce', 'github').
+ * - identity_provider: id is 'okta' or 'entra_id'.
+ * - org_service: id is the kebab-case service name (e.g. 'checkout-api').
+ *
+ * entityId is a deterministic, globally unique identifier used as service.entity.id.
+ */
+export interface Service {
+  id: string;
+  name: string;
+  kind: ServiceKind;
+  provider?: CloudProvider;
+  ownerEmployeeId?: string;
+  hostIds?: string[];
+  entityId: string;
+}
+
+/**
  * Cloud resource in the organization's infrastructure
  */
 export interface CloudResource {
@@ -217,6 +249,7 @@ export interface Organization {
   githubOrg: GitHubOrg;
   cloudflareZones: CloudflareZone[];
   onePasswordVaults: OnePasswordVault[];
+  services: Service[];
   productivitySuite: ProductivitySuite;
   centralAgent: CentralAgent;
 }
@@ -1222,4 +1255,7 @@ export interface CorrelationMap {
   jamfUdidToDevice: Map<string, { employee: Employee; device: Device }>;
   adDnToEmployee: Map<string, Employee>;
   windowsSidToEmployee: Map<string, Employee>;
+  serviceIdToService: Map<string, Service>;
+  serviceEntityIdToService: Map<string, Service>;
+  hostIdToServices: Map<string, Service[]>;
 }


### PR DESCRIPTION
Introduce a service catalog to represent cloud platforms, SaaS apps, and internal microservices. This allows integrations to consistently populate service metadata and entity IDs in generated logs, enabling better correlation between infrastructure and application telemetry.

**Screenshot of generated data in Entity analytics**


<img width="1487" height="809" alt="image" src="https://github.com/user-attachments/assets/b088407c-054b-4121-a93c-9d0c1113b13f" />
