### PR TITLE
Add spread option to Entity Store Perfomance

### DIFF
--- a/src/commands/entity_store_perf/entity_store_perf.ts
+++ b/src/commands/entity_store_perf/entity_store_perf.ts
@@ -1021,12 +1021,14 @@ export const uploadFile = async ({
   lineCount,
   modifyDoc,
   onComplete,
+  timestampSpreadMs,
 }: {
   filePath: string;
   index: string;
   lineCount: number;
   modifyDoc?: (doc: Record<string, any>) => Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   onComplete?: () => void;
+  timestampSpreadMs?: number;
 }) => {
   const stream = fs.createReadStream(filePath);
   const progress = createProgressBar('upload', {
@@ -1045,6 +1047,10 @@ export const uploadFile = async ({
     }
   };
 
+  // End of spread window is fixed at the start of the upload so all timestamps
+  // fall in [endTime - spread, endTime] regardless of upload duration.
+  const spreadEndTime = Date.now();
+
   await streamingBulkIngest({
     index,
     datasource: lineGenerator(),
@@ -1055,7 +1061,10 @@ export const uploadFile = async ({
         throw new Error('Stopped');
       }
       const record = doc as Record<string, unknown>;
-      record['@timestamp'] = new Date().toISOString();
+      record['@timestamp'] =
+        timestampSpreadMs !== undefined
+          ? new Date(spreadEndTime - Math.floor(Math.random() * timestampSpreadMs)).toISOString()
+          : new Date().toISOString();
       const payload = modifyDoc ? modifyDoc(doc as Record<string, any>) : doc; // eslint-disable-line @typescript-eslint/no-explicit-any
       return [{ create: { _index: index } }, { ...payload }];
     },
@@ -1092,6 +1101,7 @@ export const uploadPerfDataFile = async (
     samplingIntervalMs: number;
     transformTimeoutMs: number;
   },
+  timestampSpreadMs?: number,
 ) => {
   const index = indexOverride || `logs-perftest.${name}-default`;
   const entityIndex = noTransforms ? ENTITY_INDEX_V2 : ENTITY_INDEX_V1;
@@ -1152,8 +1162,12 @@ export const uploadPerfDataFile = async (
     }
   }
 
+  if (timestampSpreadMs !== undefined) {
+    log.info(`Spreading document @timestamp values randomly over the last ${timestampSpreadMs}ms`);
+  }
+
   try {
-    await uploadFile({ filePath, index, lineCount });
+    await uploadFile({ filePath, index, lineCount, timestampSpreadMs });
     const ingestTook = Date.now() - startTime;
     log.info(`Data file ${name} uploaded to index ${index} in ${ingestTook}ms`);
 

--- a/src/commands/entity_store_perf/index.ts
+++ b/src/commands/entity_store_perf/index.ts
@@ -1,7 +1,12 @@
 import { type Command } from 'commander';
 import { type CommandModule } from '../types.ts';
 import { log } from '../../utils/logger.ts';
-import { parseIntBase10, promptForFileSelection, wrapAction } from '../utils/cli_utils.ts';
+import {
+  parseDuration,
+  parseIntBase10,
+  promptForFileSelection,
+  wrapAction,
+} from '../utils/cli_utils.ts';
 import {
   createPerfDataFile,
   listPerfDataFiles,
@@ -127,9 +132,17 @@ export const entityStorePerfCommands: CommandModule = {
         30,
       )
       .option('--noTransforms', 'Use Entity Store V2 / ESQL flow (no transforms)')
+      .option(
+        '--timestamp-spread <duration>',
+        'Spread document @timestamp values randomly over the given duration ending at now (e.g., 2h, 30m, 1d, 500ms)',
+      )
       .description('Upload performance data file')
       .action(
         wrapAction(async (file, options) => {
+          const timestampSpreadMs =
+            options.timestampSpread !== undefined
+              ? parseDuration(options.timestampSpread as string)
+              : undefined;
           await uploadPerfDataFile(
             file ?? (await promptForFileSelection(listPerfDataFiles())),
             options.index,
@@ -140,6 +153,7 @@ export const entityStorePerfCommands: CommandModule = {
               samplingIntervalMs: options.samplingInterval * 1000,
               transformTimeoutMs: options.transformTimeout * 60 * 1000,
             },
+            timestampSpreadMs,
           );
         }),
       );

--- a/src/commands/utils/cli_utils.ts
+++ b/src/commands/utils/cli_utils.ts
@@ -6,6 +6,24 @@ export const parseIntBase10 = (input: string) => parseInt(input, 10);
 export const parseOptionInt = (input: string | undefined, fallback: number): number =>
   input ? parseIntBase10(input) : fallback;
 
+const DURATION_UNIT_MS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+};
+
+export const parseDuration = (input: string): number => {
+  const match = /^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/.exec(input.trim());
+  if (!match) {
+    throw new Error(
+      `Invalid duration "${input}". Expected format: <number><ms|s|m|h|d> (e.g., 2h, 30m, 500ms)`,
+    );
+  }
+  return Math.floor(parseFloat(match[1]) * DURATION_UNIT_MS[match[2]]);
+};
+
 const formatCauseChain = (error: unknown): string[] => {
   const chain: string[] = [];
   let cursor: unknown = error;


### PR DESCRIPTION
To make some tests better we need to spread logs across a period (e.g test lagging behind). This PR allows it to happen