### PR TITLE
feat(org-data): add okta owns relationship and --doc-count scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,18 +160,34 @@ Enable detection rules without prompting:
 yarn start org-data --size medium --detection-rules
 ```
 
+Scale the dataset to an approximate total document count with `--doc-count`. The employee
+population is sized so the enabled integrations produce roughly the requested number of documents
+(overriding the size-based employee count):
+
+```bash
+yarn start org-data --integrations active_directory,okta --doc-count 100000
+```
+
 Each prompt is skipped individually when its flag is present. Omit any flag to be prompted for it:
 
-| Flag                   | Values                                      | Default (when omitted)   |
-| ---------------------- | ------------------------------------------- | ------------------------ |
-| `--size`               | `john-doe`, `small`, `medium`, `enterprise` | interactive prompt       |
-| `--productivity-suite` | `microsoft`, `google`                       | interactive prompt       |
-| `--detection-rules`    | flag (boolean)                              | interactive prompt       |
-| `--integrations`       | comma-separated list                        | all default integrations |
-| `--all`                | flag (boolean)                              | —                        |
-| `--name`               | string                                      | `Acme CRM`               |
-| `--space`              | string                                      | `default`                |
-| `--seed`               | number                                      | random                   |
+| Flag                   | Values                                      | Default (when omitted)    |
+| ---------------------- | ------------------------------------------- | ------------------------- |
+| `--size`               | `john-doe`, `small`, `medium`, `enterprise` | interactive prompt        |
+| `--productivity-suite` | `microsoft`, `google`                       | interactive prompt        |
+| `--detection-rules`    | flag (boolean)                              | interactive prompt        |
+| `--integrations`       | comma-separated list                        | all default integrations  |
+| `--all`                | flag (boolean)                              | —                         |
+| `--doc-count`          | number                                      | size-based employee count |
+| `--name`               | string                                      | `Acme CRM`                |
+| `--space`              | string                                      | `default`                 |
+| `--seed`               | number                                      | random                    |
+
+> **Note on `--doc-count`**: the total is an approximation — it back-computes the employee count
+> from the enabled integrations' per-employee document yield (e.g. Okta ≈ 3 docs/employee,
+> Active Directory ≈ 1.35 docs/employee), so the actual count lands near the target rather than
+> exactly on it. When `--doc-count` is set and `--size` is omitted, size defaults to `enterprise`
+> (it only affects non-employee config such as hosts and cloud resources), so the command runs
+> without prompting.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Each prompt is skipped individually when its flag is present. Omit any flag to b
 
 | Flag                   | Values                                      | Default (when omitted)    |
 | ---------------------- | ------------------------------------------- | ------------------------- |
-| `--size`               | `john-doe`, `small`, `medium`, `enterprise` | interactive prompt        |
+| `--size`               | `john_doe`, `small`, `medium`, `enterprise` | interactive prompt        |
 | `--productivity-suite` | `microsoft`, `google`                       | interactive prompt        |
 | `--detection-rules`    | flag (boolean)                              | interactive prompt        |
 | `--integrations`       | comma-separated list                        | all default integrations  |

--- a/src/commands/org_data/index.ts
+++ b/src/commands/org_data/index.ts
@@ -19,6 +19,11 @@ export const orgDataCommands: CommandModule = {
         `Comma-separated integrations to enable (available: ${getAvailableIntegrations().join(', ')})`,
       )
       .option('--all', 'Generate all integrations regardless of company size')
+      .option(
+        '--doc-count <count>',
+        'Target total document count; scales the employee population for the enabled integrations to approximately hit this number (overrides size-based employee count)',
+        parseIntBase10,
+      )
       .option('--detection-rules', 'Include sample detection rules for applicable integrations')
       .option(
         '--size <size>',
@@ -38,6 +43,7 @@ export const orgDataCommands: CommandModule = {
             seed: options.seed,
             integrations: options.integrations,
             all: options.all,
+            docCount: options.docCount,
             detectionRules: options.detectionRules,
             productivitySuite: options.productivitySuite,
           });

--- a/src/commands/org_data/integrations/okta_integration.ts
+++ b/src/commands/org_data/integrations/okta_integration.ts
@@ -24,6 +24,15 @@ import { faker } from '@faker-js/faker';
 const IDENTITY_SOURCE = 'okta-saas-organization';
 const ENTITY_DATASET = 'entityanalytics_okta.entity';
 
+/** Maps internal device platforms to Okta's platform enum. */
+const OKTA_PLATFORM_MAPPING: Record<string, string> = {
+  mac: 'MACOS',
+  windows: 'WINDOWS',
+  linux: 'LINUX',
+  android: 'ANDROID',
+  ios: 'IOS',
+};
+
 /**
  * Okta Entity Analytics Integration
  */
@@ -112,6 +121,21 @@ export class OktaIntegration extends BaseIntegration {
         username: report.email,
       }));
 
+    // Enrolled devices become the owns relationship (user -> host). The entity pipeline
+    // reads the raw top-level `devices[]` and builds user.entity.relationships.owns.host.{id,name}
+    // from device.id and device.profile.displayName.
+    const devices = employee.devices.map((device) => ({
+      id: device.id,
+      status: 'ACTIVE',
+      created: createdDate,
+      lastUpdated: lastUpdated,
+      profile: {
+        displayName: device.displayName,
+        platform: OKTA_PLATFORM_MAPPING[device.platform] ?? device.platform.toUpperCase(),
+        serialNumber: device.serialNumber,
+      },
+    }));
+
     return {
       '@timestamp': timestamp,
       agent: this.buildCentralAgent(org),
@@ -177,8 +201,38 @@ export class OktaIntegration extends BaseIntegration {
         assignmentType: r.assignment_type,
         lastUpdated: r.last_updated ?? r.created ?? lastUpdated,
       })),
-      user: { id: employee.oktaUserId },
+      user: {
+        id: employee.oktaUserId,
+        // Post-pipeline relationship shapes, written directly so they are present even when
+        // the generated docs are not run through the entity ingest pipeline. owns.host.id uses
+        // the same device ids that createDeviceDocument writes to host.id, so the user owns
+        // relationship resolves to the generated device (host) entities.
+        ...((devices.length > 0 || supervises.length > 0) && {
+          entity: {
+            relationships: {
+              ...(devices.length > 0 && {
+                owns: {
+                  host: {
+                    id: devices.map((d) => d.id),
+                    name: devices.map((d) => d.profile.displayName),
+                  },
+                },
+              }),
+              ...(supervises.length > 0 && {
+                supervises: {
+                  user: {
+                    id: supervises.map((s) => s.user_id),
+                    name: supervises.map((s) => s.username),
+                    email: supervises.map((s) => s.email),
+                  },
+                },
+              }),
+            },
+          },
+        }),
+      },
       ...(supervises.length > 0 && { supervises }),
+      ...(devices.length > 0 && { devices }),
       labels: { identity_source: IDENTITY_SOURCE },
       data_stream: {
         namespace: 'default',
@@ -204,15 +258,7 @@ export class OktaIntegration extends BaseIntegration {
     const lastUpdated = faker.date.recent({ days: 30 }).toISOString();
     const statusChanged = faker.date.past({ years: 0.5 }).toISOString();
 
-    const platformMapping: Record<string, string> = {
-      mac: 'MACOS',
-      windows: 'WINDOWS',
-      linux: 'LINUX',
-      android: 'ANDROID',
-      ios: 'IOS',
-    };
-
-    const platform = platformMapping[device.platform] || device.platform.toUpperCase();
+    const platform = OKTA_PLATFORM_MAPPING[device.platform] || device.platform.toUpperCase();
     const diskEncryptionType = device.diskEncryptionEnabled ? 'ALL_INTERNAL_VOLUMES' : 'NONE';
     const displayName = device.displayName;
 
@@ -263,6 +309,9 @@ export class OktaIntegration extends BaseIntegration {
         },
       },
       device: { id: device.id },
+      // Mirror the device pipeline, which sets host.id from the Okta device id so the device
+      // entity is keyed as host:<device.id> and the user owns relationship resolves to it.
+      host: { id: device.id },
       labels: { identity_source: IDENTITY_SOURCE },
       data_stream: {
         namespace: 'default',

--- a/src/commands/org_data/org_data.ts
+++ b/src/commands/org_data/org_data.ts
@@ -11,6 +11,7 @@ import {
   type OrganizationSize,
   type OrganizationConfig,
   type ProductivitySuite,
+  type IntegrationName,
 } from './types.ts';
 import { generateOrgData, getOrgDataSummary } from './org_data_generator.ts';
 import { buildCorrelationMap, verifyCorrelationIntegrity } from './correlation.ts';
@@ -86,6 +87,48 @@ const promptForProductivitySuite = async (): Promise<ProductivitySuite> => {
   });
 };
 
+/**
+ * Approximate number of documents each integration emits per employee.
+ *
+ * Used by the --doc-count option to back-compute the employee population needed
+ * to hit a target document count. Each employee has ~2 devices (1 laptop + 1 mobile);
+ * the laptop platform is weighted mac 50% / windows 35% / linux 15%.
+ *
+ *  - okta (entityanalytics_okta): 1 user doc + ~2 device docs ≈ 3
+ *  - entra_id (entityanalytics_entra_id): 1 user doc + ~2 device docs ≈ 3
+ *  - active_directory: 1 user doc + ~0.35 windows computer doc ≈ 1.35
+ *
+ * Anything not listed here is a log-style integration whose volume varies; we use
+ * a conservative default so the estimate doesn't wildly under-count.
+ */
+const DOCS_PER_EMPLOYEE_ESTIMATE: Partial<Record<IntegrationName, number>> = {
+  okta: 3,
+  entra_id: 3,
+  active_directory: 1.35,
+};
+
+const DEFAULT_DOCS_PER_EMPLOYEE = 3;
+
+/**
+ * Estimate the employee count required for the enabled integrations to produce
+ * approximately `docCount` total documents.
+ */
+const estimateEmployeeCountForDocCount = (
+  docCount: number,
+  enabledIntegrations: IntegrationName[],
+): number => {
+  const docsPerEmployee = enabledIntegrations.reduce(
+    (sum, name) => sum + (DOCS_PER_EMPLOYEE_ESTIMATE[name] ?? DEFAULT_DOCS_PER_EMPLOYEE),
+    0,
+  );
+
+  if (docsPerEmployee <= 0) {
+    return 1;
+  }
+
+  return Math.max(1, Math.round(docCount / docsPerEmployee));
+};
+
 const runOrgDataHelper = async (
   options: Omit<OrganizationOptions, 'detectionRules'> & {
     detectionRules: boolean;
@@ -106,11 +149,23 @@ const runOrgDataHelper = async (
     process.exit(1);
   }
 
+  // When a target doc count is requested, scale the employee population to hit it.
+  const docCount = validatedOptions.docCount;
+  const employeeCountOverride =
+    docCount !== undefined && docCount > 0
+      ? estimateEmployeeCountForDocCount(docCount, enabledIntegrations)
+      : undefined;
+
   log.info(`Organization: ${name}`);
   log.info(`Size: ${size}`);
   log.info(`Space: ${space}`);
   log.info(`Seed: ${seed}`);
   log.info(`Integrations: ${enabledIntegrations.join(', ')}`);
+  if (employeeCountOverride !== undefined) {
+    log.info(
+      `Target doc count: ${docCount} → scaling to ~${employeeCountOverride} employees for the enabled integrations`,
+    );
+  }
   log.info('');
 
   // Generate organization
@@ -121,6 +176,7 @@ const runOrgDataHelper = async (
     size,
     seed,
     productivitySuite: validatedOptions.productivitySuite,
+    employeeCount: employeeCountOverride,
   };
 
   const organization = generateOrgData(orgConfig);
@@ -177,8 +233,12 @@ const runOrgDataHelper = async (
 export const runOrgData = async (options: OrganizationOptions): Promise<void> => {
   log.info('\n=== Correlated Organization Data Generator ===\n');
 
-  // Prompt for organization size only if not provided via CLI
-  const size = options.size ?? (await promptForSize());
+  // Prompt for organization size only if not provided via CLI. When --doc-count is
+  // set, the employee population is derived from the target instead, so default the
+  // size (it only affects non-employee config like hosts/cloud) to avoid blocking
+  // the command on an interactive prompt.
+  const size =
+    options.size ?? (options.docCount === undefined ? await promptForSize() : 'enterprise');
 
   // Prompt for productivity suite only if not provided via CLI
   const productivitySuite = options.productivitySuite ?? (await promptForProductivitySuite());
@@ -209,6 +269,7 @@ interface ValidatedOptions {
   seed: number;
   integrations: string;
   employeeCount?: number;
+  docCount?: number;
   productivitySuite: ProductivitySuite;
   detectionRules?: boolean;
 }
@@ -236,6 +297,7 @@ const validateOptions = async (options: OrganizationOptions): Promise<ValidatedO
     seed,
     integrations,
     employeeCount: options.employeeCount,
+    docCount: options.docCount,
     productivitySuite,
   };
 };

--- a/src/commands/org_data/org_data.ts
+++ b/src/commands/org_data/org_data.ts
@@ -176,7 +176,7 @@ const runOrgDataHelper = async (
     size,
     seed,
     productivitySuite: validatedOptions.productivitySuite,
-    employeeCount: employeeCountOverride,
+    employeeCount: employeeCountOverride ?? validatedOptions.employeeCount,
   };
 
   const organization = generateOrgData(orgConfig);

--- a/src/commands/org_data/org_data.ts
+++ b/src/commands/org_data/org_data.ts
@@ -233,6 +233,18 @@ const runOrgDataHelper = async (
 export const runOrgData = async (options: OrganizationOptions): Promise<void> => {
   log.info('\n=== Correlated Organization Data Generator ===\n');
 
+  // Validate --doc-count up front, before any prompts. An invalid value (NaN,
+  // zero, or negative) would otherwise be treated as "defined" — skipping the
+  // size prompt and defaulting to enterprise — while the scaling is silently
+  // dropped later because it only applies when docCount > 0.
+  if (
+    options.docCount !== undefined &&
+    (!Number.isInteger(options.docCount) || options.docCount <= 0)
+  ) {
+    log.error('--doc-count must be a positive integer.');
+    process.exit(1);
+  }
+
   // Prompt for organization size only if not provided via CLI. When --doc-count is
   // set, the employee population is derived from the target instead, so default the
   // size (it only affects non-employee config like hosts/cloud) to avoid blocking

--- a/src/commands/org_data/org_data_generator.ts
+++ b/src/commands/org_data/org_data_generator.ts
@@ -61,11 +61,15 @@ export const generateOrgData = (config: OrganizationConfig): Organization => {
   const sizeConfig = SIZE_CONFIGS[config.size];
   const domain = config.domain || `${config.name.toLowerCase().replace(/\s+/g, '')}.com`;
 
-  // Calculate total employees
-  const employeeCount = faker.number.int({
-    min: sizeConfig.employeeRange.min,
-    max: sizeConfig.employeeRange.max,
-  });
+  // Calculate total employees. An explicit employeeCount override (e.g. from the
+  // --doc-count scaling option) takes precedence over the size-based range.
+  const employeeCount =
+    config.employeeCount !== undefined && config.employeeCount > 0
+      ? config.employeeCount
+      : faker.number.int({
+          min: sizeConfig.employeeRange.min,
+          max: sizeConfig.employeeRange.max,
+        });
 
   // Generate departments with Okta groups
   const oktaGroups = generateOktaGroups();

--- a/src/commands/org_data/types.ts
+++ b/src/commands/org_data/types.ts
@@ -229,6 +229,11 @@ export interface OrganizationConfig {
   size: OrganizationSize;
   seed?: number;
   productivitySuite?: ProductivitySuite;
+  /**
+   * Explicit employee count override. When set, this takes precedence over the
+   * size-based employee range (used by the --doc-count scaling option).
+   */
+  employeeCount?: number;
 }
 
 /**
@@ -1096,6 +1101,11 @@ export interface OrganizationOptions {
   seed?: number;
   integrations: string;
   employeeCount?: number;
+  /**
+   * Target total document count. When set, the employee population is scaled so
+   * the enabled integrations produce approximately this many documents.
+   */
+  docCount?: number;
   productivitySuite?: ProductivitySuite;
   all?: boolean;
   detectionRules?: boolean;


### PR DESCRIPTION
## Summary

Two `org-data` changes:

**1. Okta `owns` + `supervises` post-pipeline relationships**

Extends the Okta identity integration to emit the relationship shapes consumed by the Entity Store v2 relationship maintainers.

- **`owns` (user → host)** — emits the raw top-level `devices[]` array of `{ id, status, created, lastUpdated, profile: { displayName, platform, serialNumber } }` for each user's enrolled devices (the pre-pipeline shape the ingest pipeline reads to build `user.entity.relationships.owns.host.{id,name}`).
- Sets `host.id` on the Okta device documents (mirroring the device pipeline) so the device entity is keyed as `host:<device.id>` and the user `owns` relationship resolves to the generated device (host) entity.
- **`supervises` (user → user)** — in addition to the raw top-level `supervises[]` array (added in #406), now also writes the post-pipeline `user.entity.relationships.supervises.user.{id,name,email}` shape.
- Both `owns` and `supervises` post-pipeline shapes are written directly under `user.entity.relationships`, so the relationships are present even when the generated docs bypass the entity ingest pipeline.
- Hoists the internal-platform → Okta-platform enum mapping to a shared module constant so user and device docs use the same mapping.

**2. `--doc-count` scaling option**

Adds a `--doc-count <count>` flag to `org-data` that back-computes the employee population needed for the enabled integrations to produce approximately the requested total document count, overriding the size-based employee count.

- Estimates per-employee document yield per integration (okta ≈ 3, entra_id ≈ 3, active_directory ≈ 1.35; conservative default of 3 for others) and scales the employee count accordingly.
- When `--doc-count` is set and `--size` is omitted, size defaults to `enterprise` (size only affects non-employee config like hosts/cloud resources), so the command runs without an interactive prompt.

## Why

The `owns` and `supervises` Entity Store v2 maintainers need realistic Okta source data (user → host device ownership, user → user reporting) to develop and test against, complementing the `administers`/`supervises` source fields added in #406. The `--doc-count` option makes it easy to generate approximately-sized datasets for scale/perf testing of the maintainers and entity store without hand-tuning employee counts.

## Relationship resolvability

| Integration | Relationship | Identifiers emitted | Resolvable? |
| ----------- | ------------ | ------------------- | ----------- |
| Okta | owns (user→host) | host.id (Okta device id), host.name (device displayName) | ✅ device docs set `host.id` = device id, so `owns.host.id` matches the device's `host:<device.id>` EUID |
| Okta | supervises (user→user) | user.id (Okta id), user.name (login), user.email | ✅ all map to user EUID ranking |

Maintainer resolution priority: host targets `host.id` → `host.name`; user targets `user.email` → `user.id` → `user.name`.

## Test plan

- `yarn start org-data --integrations okta` — verify user docs include the raw `devices[]` array and the post-pipeline `user.entity.relationships.owns.host.{id,name}` and `user.entity.relationships.supervises.user.{id,name,email}`, and that device docs set `host.id` to the Okta device id.
- After ingest, confirm the integration pipeline builds `user.entity.relationships.{owns,supervises}` and the maintainers resolve the host/user targets to the generated EUIDs.
- `yarn start org-data --integrations active_directory,okta --doc-count 100000` — verify the run logs the scaled employee count and completes without prompting, and that the resulting total document count lands near the target.
- `yarn start org-data --integrations okta --doc-count 5000` — verify a smaller target scales down the employee population accordingly.

## Notes / follow-ups

- `--doc-count` is an approximation: the per-employee yield estimates assume ~2 devices/employee and the default laptop platform weighting, so the actual total lands near the target rather than exactly on it.