### PR TITLE
feat(org-data): rename cloudtrail integration to aws and populate cloud.provider

### DIFF
--- a/src/commands/org_data/detection_rules.ts
+++ b/src/commands/org_data/detection_rules.ts
@@ -99,7 +99,7 @@ const INTEGRATION_DETECTION_RULES: Partial<Record<IntegrationName, DetectionRule
     },
   ],
 
-  cloudtrail: [
+  aws: [
     {
       name: 'AWS Console Login Failure',
       description: 'Detects failed AWS Management Console login attempts',

--- a/src/commands/org_data/integrations/cloudtrail_integration.ts
+++ b/src/commands/org_data/integrations/cloudtrail_integration.ts
@@ -192,6 +192,18 @@ export class CloudTrailIntegration extends BaseIntegration {
   }
 
   /**
+   * Build ECS cloud.* metadata for a CloudTrail document. In real deployments this
+   * is added by the Filebeat AWS input (not the ingest pipeline), so the generator
+   * must set it directly -- otherwise cloud.provider is never populated.
+   */
+  private buildCloud(
+    accountId: string,
+    region: string,
+  ): { provider: 'aws'; account: { id: string }; region: string } {
+    return { provider: 'aws', account: { id: accountId }, region };
+  }
+
+  /**
    * Generate all CloudTrail documents
    */
   generateDocuments(
@@ -275,7 +287,7 @@ export class CloudTrailIntegration extends BaseIntegration {
     const events: IntegrationDocument[] = [];
     const account = org.cloudAccounts.find((a) => a.id === iamUser.accountId);
     const accountResources = resources.filter((r) => r.accountId === iamUser.accountId);
-    const sessionCount = faker.number.int({ min: 1, max: 3 });
+    const sessionCount = faker.number.int({ min: 2, max: 5 });
 
     for (let s = 0; s < sessionCount; s++) {
       const sessionStart = this.getRandomTimestamp(48);
@@ -316,7 +328,7 @@ export class CloudTrailIntegration extends BaseIntegration {
       );
 
       // Generate API calls within the session
-      const apiCallCount = faker.number.int({ min: 2, max: 8 });
+      const apiCallCount = faker.number.int({ min: 4, max: 12 });
       const availableServices = this.getServicesForResources(accountResources);
 
       for (let i = 0; i < apiCallCount; i++) {
@@ -378,6 +390,7 @@ export class CloudTrailIntegration extends BaseIntegration {
               account!,
               apiTime,
               targetInstance,
+              org,
             ),
           );
         }
@@ -398,7 +411,7 @@ export class CloudTrailIntegration extends BaseIntegration {
     const events: IntegrationDocument[] = [];
     const account = org.cloudAccounts.find((a) => a.id === iamUser.accountId);
     const accountResources = resources.filter((r) => r.accountId === iamUser.accountId);
-    const eventCount = faker.number.int({ min: 5, max: 15 });
+    const eventCount = faker.number.int({ min: 10, max: 25 });
     const accessKeyId = this.generatePermanentAccessKeyId();
 
     for (let i = 0; i < eventCount; i++) {
@@ -441,6 +454,7 @@ export class CloudTrailIntegration extends BaseIntegration {
             account!,
             timestamp,
             targetInstance,
+            org,
           ),
         );
       }
@@ -484,7 +498,7 @@ export class CloudTrailIntegration extends BaseIntegration {
   ): IntegrationDocument[] {
     const events: IntegrationDocument[] = [];
     const account = org.cloudAccounts.find((a) => a.id === iamUser.accountId);
-    const sessionCount = faker.number.int({ min: 1, max: 3 });
+    const sessionCount = faker.number.int({ min: 2, max: 4 });
 
     for (let i = 0; i < sessionCount; i++) {
       const host = faker.helpers.arrayElement(awsHosts);
@@ -500,6 +514,7 @@ export class CloudTrailIntegration extends BaseIntegration {
           assumedRoleArn,
           timestamp,
           accessKeyId,
+          org,
         ),
       );
     }
@@ -517,6 +532,7 @@ export class CloudTrailIntegration extends BaseIntegration {
     assumedRoleArn: string,
     timestamp: string,
     accessKeyId: string,
+    org: Organization,
   ): IntegrationDocument {
     const eventId = faker.string.uuid();
     const sourceIp = faker.internet.ipv4();
@@ -569,6 +585,7 @@ export class CloudTrailIntegration extends BaseIntegration {
     const service = this.serviceAttachmentFor('ssm.amazonaws.com');
     return {
       '@timestamp': timestamp,
+      agent: this.buildCentralAgent(org),
       message: JSON.stringify(rawEvent),
       event: {
         dataset: 'aws.cloudtrail',
@@ -579,6 +596,7 @@ export class CloudTrailIntegration extends BaseIntegration {
         kind: 'event',
       },
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      cloud: this.buildCloud(account.id, region),
       user: { entity: { id: assumedRoleArn } },
       host: { id: host.id, name: host.name },
       ...(service && { service }),
@@ -646,6 +664,7 @@ export class CloudTrailIntegration extends BaseIntegration {
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      cloud: this.buildCloud(account.id, 'us-east-1'),
       ...(service && { service }),
     } as IntegrationDocument;
   }
@@ -710,6 +729,7 @@ export class CloudTrailIntegration extends BaseIntegration {
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      cloud: this.buildCloud(account.id, 'us-east-1'),
       ...(service && { service }),
     } as IntegrationDocument;
   }
@@ -795,6 +815,7 @@ export class CloudTrailIntegration extends BaseIntegration {
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      cloud: this.buildCloud(account.id, region),
       ...(serviceAttachment && { service: serviceAttachment }),
     } as IntegrationDocument;
   }
@@ -853,6 +874,7 @@ export class CloudTrailIntegration extends BaseIntegration {
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      cloud: this.buildCloud(account.id, region),
       ...(serviceAttachment && { service: serviceAttachment }),
     } as IntegrationDocument;
   }
@@ -925,6 +947,7 @@ export class CloudTrailIntegration extends BaseIntegration {
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      cloud: this.buildCloud(account.id, 'us-east-1'),
       ...(service && { service }),
     } as IntegrationDocument;
   }
@@ -939,6 +962,7 @@ export class CloudTrailIntegration extends BaseIntegration {
     account: CloudAccount,
     timestamp: string,
     instance: CloudResource,
+    org: Organization,
   ): IntegrationDocument {
     const hostTargetEvent = faker.helpers.arrayElement(HOST_TARGET_EVENTS);
     const params = hostTargetEvent.buildParams(instance.id);
@@ -966,9 +990,11 @@ export class CloudTrailIntegration extends BaseIntegration {
     const service = this.serviceAttachmentFor(hostTargetEvent.eventSource);
     return {
       '@timestamp': timestamp,
+      agent: this.buildCentralAgent(org),
       message: JSON.stringify(rawEvent),
       tags: CLOUDTRAIL_TAGS,
       data_stream: { namespace: 'default', type: 'logs', dataset: 'aws.cloudtrail' },
+      cloud: this.buildCloud(account.id, instance.region),
       ...(service && { service }),
     } as IntegrationDocument;
   }

--- a/src/commands/org_data/integrations/index.ts
+++ b/src/commands/org_data/integrations/index.ts
@@ -130,7 +130,7 @@ export const createIntegrationRegistry = (): IntegrationRegistry => {
 
   // Register log integrations
   registry.set('okta_system', new OktaSystemIntegration());
-  registry.set('cloudtrail', new CloudTrailIntegration());
+  registry.set('aws', new CloudTrailIntegration());
 
   // Register new integrations
   registry.set('crowdstrike', new CrowdStrikeIntegration());
@@ -222,7 +222,7 @@ export const getAvailableIntegrations = (): IntegrationName[] => {
     'okta',
     'cloud_asset',
     'okta_system',
-    'cloudtrail',
+    'aws',
     'entra_id',
     'crowdstrike',
     'o365',

--- a/src/commands/org_data/integrations/index.ts
+++ b/src/commands/org_data/integrations/index.ts
@@ -62,6 +62,7 @@ import { TeleportIntegration } from './teleport_integration.ts';
 import { ThycoticSsIntegration } from './thycotic_ss_integration.ts';
 import { ZoomIntegration } from './zoom_integration.ts';
 import { type IntegrationName } from '../types.ts';
+import { log } from '../../../utils/logger.ts';
 
 // Re-export types and classes from base_integration
 export type { IntegrationRegistry, IntegrationResult, IntegrationDocument, DataStreamConfig };
@@ -273,10 +274,28 @@ export const getAvailableIntegrations = (): IntegrationName[] => {
 };
 
 /**
+ * Deprecated CLI integration names that still resolve, mapped to their current
+ * IntegrationName. Keeps existing scripts/docs working after a rename.
+ */
+const DEPRECATED_INTEGRATION_ALIASES: Record<string, IntegrationName> = {
+  cloudtrail: 'aws',
+};
+
+/**
  * Parse comma-separated integration list
  */
 export const parseIntegrationList = (list: string): IntegrationName[] => {
   const available = getAvailableIntegrations();
-  const requested = list.split(',').map((s) => s.trim() as IntegrationName);
-  return requested.filter((name) => available.includes(name));
+  const requested = list.split(',').map((s) => {
+    const trimmed = s.trim();
+    const alias = DEPRECATED_INTEGRATION_ALIASES[trimmed];
+    if (alias) {
+      log.warn(`Integration name "${trimmed}" is deprecated, use "${alias}" instead.`);
+      return alias;
+    }
+    return trimmed as IntegrationName;
+  });
+  // Dedupe so specifying both the alias and the canonical name doesn't run it twice
+  const deduped = Array.from(new Set(requested));
+  return deduped.filter((name) => available.includes(name));
 };

--- a/src/commands/org_data/org_data.ts
+++ b/src/commands/org_data/org_data.ts
@@ -705,7 +705,7 @@ Available Integrations:
 
   Log Integrations (Original):
     okta_system        - Okta System Logs (authentication, SSO, MFA events)
-    cloudtrail         - AWS CloudTrail (API calls, console logins, role assumptions)
+    aws                - AWS CloudTrail (API calls, console logins, role assumptions)
 
   Endpoint Security:
     crowdstrike        - CrowdStrike Falcon (host inventory + EDR alerts)
@@ -767,7 +767,7 @@ Examples:
   yarn start org-data --name "MegaCorp CRM"
 
   # Generate with only original integrations
-  yarn start org-data --integrations okta,entra_id,cloud_asset,okta_system,cloudtrail
+  yarn start org-data --integrations okta,entra_id,cloud_asset,okta_system,aws
 
   # Generate with endpoint + identity stack
   yarn start org-data --integrations okta,entra_id,crowdstrike,cisco_duo,1password

--- a/src/commands/org_data/org_data_generator.ts
+++ b/src/commands/org_data/org_data_generator.ts
@@ -721,16 +721,30 @@ const generateCloudIamUsers = (employees: Employee[], accounts: CloudAccount[]):
   // Get employees with AWS access (Product & Engineering)
   const awsEmployees = employees.filter((e) => e.hasAwsAccess);
 
-  // Use the production account for federated users
+  // Use the production account as the default/fallback (e.g. for service accounts)
   const prodAccount = awsAccounts.find((a) => a.environment === 'production') || awsAccounts[0];
 
+  // Distribute federated users across all AWS accounts so CloudTrail activity
+  // (and cloud.account.id) isn't concentrated on a single account. Production
+  // is weighted highest since most employees primarily work against prod.
+  const pickAccountForEmployee = (): CloudAccount => {
+    if (awsAccounts.length === 1) return awsAccounts[0];
+    return faker.helpers.weightedArrayElement(
+      awsAccounts.map((account) => ({
+        value: account,
+        weight: account.environment === 'production' ? 5 : 2,
+      })),
+    );
+  };
+
   for (const employee of awsEmployees) {
+    const account = pickAccountForEmployee();
     iamUsers.push({
       id: faker.string.alphanumeric(21).toUpperCase(),
-      arn: `arn:aws:iam::${prodAccount.id}:user/${employee.userName}`,
+      arn: `arn:aws:iam::${account.id}:user/${employee.userName}`,
       userName: employee.userName,
       provider: 'aws',
-      accountId: prodAccount.id,
+      accountId: account.id,
       isFederated: true,
       oktaUserId: employee.oktaUserId,
       createdAt: faker.date.past({ years: 2 }).toISOString(),

--- a/src/commands/org_data/types.ts
+++ b/src/commands/org_data/types.ts
@@ -16,7 +16,11 @@ export type DeviceType = 'laptop' | 'mobile';
 
 // Department names as a union type for type safety
 export type DepartmentName =
-  'Product & Engineering' | 'Sales & Marketing' | 'Customer Success' | 'Operations' | 'Executive';
+  | 'Product & Engineering'
+  | 'Sales & Marketing'
+  | 'Customer Success'
+  | 'Operations'
+  | 'Executive';
 
 // Productivity suite type (Microsoft 365 vs Google Workspace)
 export type ProductivitySuite = 'microsoft' | 'google';
@@ -1069,7 +1073,11 @@ export interface CloudTrailDocument {
  * CloudTrail user identity types
  */
 export type CloudTrailUserIdentityType =
-  'IAMUser' | 'AssumedRole' | 'FederatedUser' | 'Root' | 'AWSService';
+  | 'IAMUser'
+  | 'AssumedRole'
+  | 'FederatedUser'
+  | 'Root'
+  | 'AWSService';
 
 /**
  * Okta system log event types
@@ -1110,7 +1118,7 @@ export type IntegrationName =
   | 'okta'
   | 'cloud_asset'
   | 'okta_system'
-  | 'cloudtrail'
+  | 'aws'
   | 'entra_id'
   | 'crowdstrike'
   | 'o365'

--- a/src/commands/org_data/types.ts
+++ b/src/commands/org_data/types.ts
@@ -16,11 +16,7 @@ export type DeviceType = 'laptop' | 'mobile';
 
 // Department names as a union type for type safety
 export type DepartmentName =
-  | 'Product & Engineering'
-  | 'Sales & Marketing'
-  | 'Customer Success'
-  | 'Operations'
-  | 'Executive';
+  'Product & Engineering' | 'Sales & Marketing' | 'Customer Success' | 'Operations' | 'Executive';
 
 // Productivity suite type (Microsoft 365 vs Google Workspace)
 export type ProductivitySuite = 'microsoft' | 'google';
@@ -1073,11 +1069,7 @@ export interface CloudTrailDocument {
  * CloudTrail user identity types
  */
 export type CloudTrailUserIdentityType =
-  | 'IAMUser'
-  | 'AssumedRole'
-  | 'FederatedUser'
-  | 'Root'
-  | 'AWSService';
+  'IAMUser' | 'AssumedRole' | 'FederatedUser' | 'Root' | 'AWSService';
 
 /**
  * Okta system log event types


### PR DESCRIPTION
Renames the CLI-facing AWS CloudTrail integration from `cloudtrail` to `aws` and fixes `cloud.provider` being almost never populated in generated `aws.cloudtrail` documents.

The integration's `packageName` was already `aws` internally, but it was registered and exposed to `--integrations` as `cloudtrail`, which didn't match the Fleet package name and caused `yarn start org-data --integrations aws` to fail to resolve.

`cloud.provider` is normally added by the Filebeat AWS input rather than the `aws.cloudtrail` ingest pipeline, so document generation needs to set it explicitly — at enterprise scale it was rarely showing up.

- Rename `cloudtrail` -> `aws` in `types.ts` (`IntegrationName`), `integrations/index.ts` (registry + `getAvailableIntegrations`), `detection_rules.ts`, and `org_data.ts` help text/examples
- Add a `buildCloud()` helper in `cloudtrail_integration.ts` and spread `cloud.provider`/`cloud.account.id`/`cloud.region` into all 7 document factories
- Distribute federated IAM users across all cloud accounts (previously all landed on production) and bump `sessionCount`/`apiCallCount`/`eventCount` ranges to increase overall AWS volume

Verified with `yarn start org-data --integrations aws` against a local ES/Kibana; `cloud.provider: aws` now shows up in the generated documents.
