### PR TITLE
fix(entity-store-perf): add --no-setup to upload-perf-data

### DIFF
--- a/src/commands/entity_store_perf/README.md
+++ b/src/commands/entity_store_perf/README.md
@@ -53,6 +53,7 @@ yarn start upload-perf-data [file] [--index <index>] [--delete] [options]
 - `--samplingInterval <seconds>`: Metrics sampling interval when `--metrics` is enabled (default: `5`)
 - `--transformTimeout <minutes>`: Generic transform wait timeout in metrics mode for V1 flow (default: `30`)
 - `--noTransforms`: Run Entity Store V2 / ESQL flow (enable V2, install V2, no transforms, v2 indices)
+- `--no-setup`: Skip the Entity Store enable/install step. Use when the target already has Entity Store installed — the install endpoint returns 500 when called against an installed store, which otherwise aborts the upload.
 - `--bulk-concurrency <n>`: Parallel `_bulk` requests per upload (default: `8`). Values above ~8 often do not increase throughput once the cluster is saturated.
 
 When `--metrics` is enabled, log files can be used with `create-baseline`/`compare-metrics` by passing the emitted prefix. In V2 mode (`--noTransforms`), transform stats are skipped.

--- a/src/commands/entity_store_perf/README.md
+++ b/src/commands/entity_store_perf/README.md
@@ -53,7 +53,7 @@ yarn start upload-perf-data [file] [--index <index>] [--delete] [options]
 - `--samplingInterval <seconds>`: Metrics sampling interval when `--metrics` is enabled (default: `5`)
 - `--transformTimeout <minutes>`: Generic transform wait timeout in metrics mode for V1 flow (default: `30`)
 - `--noTransforms`: Run Entity Store V2 / ESQL flow (enable V2, install V2, no transforms, v2 indices)
-- `--no-setup`: Skip the Entity Store enable/install step. Use when the target already has Entity Store installed — the install endpoint returns 500 when called against an installed store, which otherwise aborts the upload.
+- `--no-setup`: Skip the Entity Store V2 enable/install step (V2 flow only, i.e. with `--noTransforms`). Use when the target already has Entity Store installed — the install endpoint returns 500 when called against an installed store, which otherwise aborts the upload. The V1 engine init needs no equivalent: it already returns early when the requested engines are started.
 - `--bulk-concurrency <n>`: Parallel `_bulk` requests per upload (default: `8`). Values above ~8 often do not increase throughput once the cluster is saturated.
 
 When `--metrics` is enabled, log files can be used with `create-baseline`/`compare-metrics` by passing the emitted prefix. In V2 mode (`--noTransforms`), transform stats are skipped.

--- a/src/commands/entity_store_perf/entity_store_perf.ts
+++ b/src/commands/entity_store_perf/entity_store_perf.ts
@@ -1222,14 +1222,18 @@ export const uploadPerfDataFile = async (
     process.exit(1);
   }
 
-  if (noSetup) {
-    log.info('Skipping Entity Store setup (--no-setup flag set)');
-  } else if (noTransforms) {
-    log.info('Enabling Entity Store V2...');
-    await enableEntityStoreV2('default');
-    await installEntityStoreV2('default');
-    log.info('Entity Store V2 ready');
+  if (noTransforms) {
+    if (noSetup) {
+      log.info('Skipping Entity Store V2 enable/install (--no-setup)');
+    } else {
+      log.info('Enabling Entity Store V2...');
+      await enableEntityStoreV2('default');
+      await installEntityStoreV2('default');
+      log.info('Entity Store V2 ready');
+    }
   } else {
+    // V1 engine init is already a no-op when the engines are started, so it
+    // needs no --no-setup escape hatch.
     log.info('initialising entity engines');
     await initEntityEngineForEntityTypes(['host', 'user', 'service', 'generic']);
     log.info('entity engines initialised');

--- a/src/commands/entity_store_perf/entity_store_perf.ts
+++ b/src/commands/entity_store_perf/entity_store_perf.ts
@@ -1195,6 +1195,7 @@ export const uploadPerfDataFile = async (
   },
   timestampSpreadMs?: number,
   bulkConcurrency: number = DEFAULT_UPLOAD_BULK_CONCURRENCY,
+  noSetup?: boolean,
 ) => {
   const index = indexOverride || `logs-perftest.${name}-default`;
   const entityIndex = noTransforms ? ENTITY_INDEX_V2 : ENTITY_INDEX_V1;
@@ -1221,7 +1222,9 @@ export const uploadPerfDataFile = async (
     process.exit(1);
   }
 
-  if (noTransforms) {
+  if (noSetup) {
+    log.info('Skipping Entity Store setup (--no-setup flag set)');
+  } else if (noTransforms) {
     log.info('Enabling Entity Store V2...');
     await enableEntityStoreV2('default');
     await installEntityStoreV2('default');

--- a/src/commands/entity_store_perf/index.ts
+++ b/src/commands/entity_store_perf/index.ts
@@ -134,6 +134,7 @@ export const entityStorePerfCommands: CommandModule = {
         30,
       )
       .option('--noTransforms', 'Use Entity Store V2 / ESQL flow (no transforms)')
+      .option('--no-setup', 'Skip Entity Store enable/install (use when already installed)')
       .option(
         '--timestamp-spread <duration>',
         'Spread document @timestamp values randomly over the given duration ending at now (e.g., 2h, 30m, 1d, 500ms)',
@@ -164,6 +165,7 @@ export const entityStorePerfCommands: CommandModule = {
             },
             timestampSpreadMs,
             options.bulkConcurrency,
+            options.setup === false,
           );
         }),
       );

--- a/src/commands/entity_store_perf/index.ts
+++ b/src/commands/entity_store_perf/index.ts
@@ -134,7 +134,10 @@ export const entityStorePerfCommands: CommandModule = {
         30,
       )
       .option('--noTransforms', 'Use Entity Store V2 / ESQL flow (no transforms)')
-      .option('--no-setup', 'Skip Entity Store enable/install (use when already installed)')
+      .option(
+        '--no-setup',
+        'Skip the Entity Store V2 enable/install step (V2 flow only; use when the target already has Entity Store installed)',
+      )
       .option(
         '--timestamp-spread <duration>',
         'Spread document @timestamp values randomly over the given duration ending at now (e.g., 2h, 30m, 1d, 500ms)',


### PR DESCRIPTION
## Why

`upload-perf-data` unconditionally calls the Entity Store enable + install endpoints before uploading. Against an environment that already has Entity Store installed, `POST /api/security/entity_store/install` returns a 500 and the command aborts before any data is written — so there was no way to add perf data to an existing cluster.

Hit while seeding 5M entities into a serverless QA project for Entity Analytics grouping performance validation ([kibana#279302](https://github.com/elastic/kibana/pull/279302)). Reinstalling was not an option there: install is only accepted once per project, and uninstall would have discarded the seeded data.

## Notes for reviewers

`--no-setup` is scoped to the V2 flow (`--noTransforms`). The V1 transform path deliberately has no equivalent: `initEntityEngineForEntityTypes` already returns early when the requested engines are started, so it is a no-op rather than a 500, and skipping it would only risk uploading into a cluster with no engines.

Commander maps `--no-setup` to `options.setup === false`, which is why the call site reads that way rather than checking a `noSetup` option.

No default behaviour changes — without the flag the command still enables and installs as before.